### PR TITLE
Implement Phase 2: server push via PubSub and handle_info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,16 +25,18 @@ Targets: `make test` (build + run tests + build examples), `make unit-tests` (te
 
 ### Public API
 
-- `LiveView` trait — user implements `mount`, `handle_event`, `render`
+- `LiveView` trait — user implements `mount`, `handle_event`, `handle_info`, `render`
 - `Assigns` — key-value store with dirty tracking, backed by `TemplateValues`
-- `Socket` — user-facing handle passed to lifecycle methods
+- `Socket` — user-facing handle passed to lifecycle methods; provides `self()`, `subscribe(topic)`, `unsubscribe(topic)`
 - `Factory` — `interface val` for creating `LiveView` instances (lambdas work via structural typing)
 - `Router` / `Routes` — mutable builder freezes into immutable `Routes val`
+- `InfoReceiver` — `interface tag` handle for sending messages to a connection from external actors
+- `PubSub` — actor for topic-based publish-subscribe across connections
 - `Listener` — actor wrapping lori's `TCPListenerActor`
 
 ### Internal
 
-- `_Connection` — one actor per client, implements `WebSocketServerActor`. Two-phase init: view is `None` until `on_open` delivers the URI for route lookup.
+- `_Connection` — one actor per client, implements `WebSocketServerActor`. Two-phase init: view is `None` until `on_open` delivers the URI for route lookup. Has `info` behavior for external message delivery; cleans up PubSub subscriptions in `on_closed`.
 - `_WireProtocol` — JSON encode/decode for the client-server wire format.
 - `_Unreachable` — panic primitive for impossible code paths.
 
@@ -52,6 +54,8 @@ livery/           # Library package (also the test compilation target)
   assigns.pony    # Assigns class
   socket.pony     # Socket class
   factory.pony    # Factory interface
+  info_receiver.pony # InfoReceiver interface
+  pub_sub.pony    # PubSub actor
   router.pony     # Router + Routes
   listener.pony   # Listener actor
   _connection.pony # Connection actor (internal)
@@ -60,6 +64,7 @@ livery/           # Library package (also the test compilation target)
   _test.pony      # All tests (single runner)
 examples/
   counter/        # Increment/decrement counter
+  ticker/         # PubSub-driven ticker (server push)
 ```
 
 ## Conventions
@@ -67,4 +72,4 @@ examples/
 - Qualified imports in library code: `use json = "json"`, `use mare = "mare"`, etc.
 - Single test runner in `livery/_test.pony` with `Main is TestList`.
 - `\nodoc\` on all test types.
-- Property-based tests (PonyCheck) for Assigns; example-based for wire protocol, router, socket.
+- Property-based tests (PonyCheck) for Assigns; example-based for wire protocol, router, socket, PubSub.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,7 @@ Each subdirectory is a self-contained Pony program demonstrating a different par
 ## [counter](counter/)
 
 Implements a simple increment/decrement counter as a `LiveView`. Registers a single route, parses a template with `HtmlTemplate`, and updates an integer assign in response to `"increment"` and `"decrement"` click events. Demonstrates the core lifecycle: `mount`, `handle_event`, and `render` with the `Router`/`Listener` setup. Start here if you're new to the library.
+
+## [ticker](ticker/)
+
+Demonstrates server push via `PubSub` and `handle_info`. A `Ticker` actor publishes to the `"tick"` topic every second. The `TickerView` subscribes in `mount` and increments a counter each time `handle_info` fires. Shows how external actors drive LiveView updates without any client interaction.

--- a/examples/counter/main.pony
+++ b/examples/counter/main.pony
@@ -42,4 +42,4 @@ actor Main
       {(): LiveView ref^ ? => CounterView.create()?} val)
 
     Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8081",
-      router.build(), env.err)
+      router.build(), PubSub, env.err)

--- a/examples/ticker/main.pony
+++ b/examples/ticker/main.pony
@@ -1,0 +1,77 @@
+use "time"
+use "templates"
+use "json"
+use lori = "lori"
+use "../../livery"
+
+class TickerView is LiveView
+  """
+  A LiveView that displays a count incremented by an external ticker.
+
+  Subscribes to the `"tick"` PubSub topic in `mount`. Each time the
+  `Ticker` actor publishes to that topic, `handle_info` fires and
+  increments the counter.
+  """
+  let _template: HtmlTemplate val
+
+  new create() ? =>
+    _template = HtmlTemplate.parse(
+      """
+      <div>
+        <h1>Ticks: {{ count }}</h1>
+        <p>Count updates automatically every second.</p>
+      </div>
+      """)?
+
+  fun ref mount(socket: Socket ref) =>
+    socket.assign("count", "0")
+    socket.subscribe("tick")
+
+  fun ref handle_event(event: String val, payload: JsonValue,
+    socket: Socket ref)
+  =>
+    None
+
+  fun ref handle_info(message: Any val, socket: Socket ref) =>
+    try
+      let current = socket.get_assign("count")?.string()?.i64()?
+      socket.assign("count", (current + 1).string())
+    end
+
+  fun box render(assigns: Assigns box): String ? =>
+    _template.render(assigns.template_values())?
+
+actor Ticker
+  """
+  Publishes a message to the `"tick"` PubSub topic every second.
+  """
+  let _pub_sub: PubSub tag
+  let _timers: Timers
+
+  new create(pub_sub: PubSub tag) =>
+    _pub_sub = pub_sub
+    _timers = Timers
+    let timer = Timer(_TickNotify(pub_sub), 1_000_000_000, 1_000_000_000)
+    _timers(consume timer)
+
+class _TickNotify is TimerNotify
+  let _pub_sub: PubSub tag
+
+  new iso create(pub_sub: PubSub tag) =>
+    _pub_sub = pub_sub
+
+  fun ref apply(timer: Timer, count: U64): Bool =>
+    _pub_sub.publish("tick", count)
+    true
+
+actor Main
+  new create(env: Env) =>
+    let pub_sub = PubSub
+    Ticker(pub_sub)
+
+    let router = Router
+    router.route("/ticker",
+      {(): LiveView ref^ ? => TickerView.create()?} val)
+
+    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8082",
+      router.build(), pub_sub, env.err)

--- a/livery/_connection.pony
+++ b/livery/_connection.pony
@@ -18,13 +18,16 @@ actor _Connection is mare.WebSocketServerActor
   let _socket: Socket ref
   var _last_html: String val = ""
   let _router: Routes val
+  let _pub_sub: PubSub tag
 
   new create(auth: lori.TCPServerAuth, fd: U32,
-    config: mare.WebSocketConfig val, routes: Routes val)
+    config: mare.WebSocketConfig val, routes: Routes val,
+    pub_sub: PubSub tag)
   =>
     _assigns = Assigns
     _pending_events = Array[(String val, json.JsonValue)]
-    _socket = Socket(_assigns, _pending_events)
+    _pub_sub = pub_sub
+    _socket = Socket(_assigns, _pending_events, this, _pub_sub)
     _router = routes
     _ws = mare.WebSocketServer(auth, fd, this, config)
 
@@ -79,6 +82,17 @@ actor _Connection is mare.WebSocketServerActor
       end
     end
 
+  be info(message: Any val) =>
+    """
+    Deliver an external message to the LiveView via handle_info.
+    Silently dropped if the view has not been mounted yet.
+    """
+    match _view
+    | let v: LiveView ref =>
+      v.handle_info(message, _socket)
+      _maybe_rerender(v)
+    end
+
   fun ref _maybe_rerender(v: LiveView ref) =>
     if _assigns.changed() then
       try
@@ -104,4 +118,4 @@ actor _Connection is mare.WebSocketServerActor
   fun ref on_closed(close_status: mare.CloseStatus,
     close_reason: String val)
   =>
-    None
+    _pub_sub.unsubscribe_all(this)

--- a/livery/_test.pony
+++ b/livery/_test.pony
@@ -29,6 +29,14 @@ actor \nodoc\ Main is TestList
     test(_TestRouterQueryStrip)
     // Socket tests
     test(_TestSocketPushEvent)
+    // PubSub tests
+    test(_TestPubSubDeliver)
+    test(_TestPubSubNoSubscribers)
+    test(_TestPubSubUnsubscribe)
+    test(_TestPubSubUnsubscribeAll)
+    test(_TestPubSubMultipleSubscribers)
+    // Socket + PubSub integration tests
+    test(_TestSocketSubscribeDeliver)
 
 // --- Test helpers ---
 
@@ -43,6 +51,56 @@ class \nodoc\ _DummyView is LiveView
 
   fun box render(assigns: Assigns box): String =>
     ""
+
+actor \nodoc\ _TestInfoReceiver is InfoReceiver
+  """
+  Test helper that completes the test on first message received.
+  """
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be info(message: Any val) =>
+    _h.complete(true)
+
+actor \nodoc\ _SentinelInfoReceiver is InfoReceiver
+  """
+  Test helper for negative tests. When it receives a message, it checks
+  that the guarded receiver was NOT called, then completes the test.
+  """
+  let _h: TestHelper
+  let _guarded: _GuardedInfoReceiver tag
+
+  new create(h: TestHelper, guarded: _GuardedInfoReceiver tag) =>
+    _h = h
+    _guarded = guarded
+
+  be info(message: Any val) =>
+    _guarded.check_not_called(_h)
+
+actor \nodoc\ _GuardedInfoReceiver is InfoReceiver
+  """
+  Test helper that tracks whether info was called. Used with
+  _SentinelInfoReceiver for negative delivery tests.
+  """
+  var _called: Bool = false
+
+  new create() => None
+
+  be info(message: Any val) =>
+    _called = true
+
+  be check_not_called(h: TestHelper) =>
+    h.assert_false(_called, "guarded receiver should not have been called")
+    h.complete(true)
+
+actor \nodoc\ _DummyInfoReceiver is InfoReceiver
+  """
+  No-op receiver for tests that need a placeholder InfoReceiver.
+  """
+  new create() => None
+  be info(message: Any val) => None
 
 // --- Assigns property tests ---
 
@@ -307,9 +365,123 @@ class \nodoc\ _TestSocketPushEvent is UnitTest
   fun apply(h: TestHelper) ? =>
     let assigns = Assigns
     let pending = Array[(String val, json.JsonValue)]
-    let socket = Socket(assigns, pending)
+    let socket = Socket(assigns, pending, _DummyInfoReceiver, PubSub)
     socket.push_event("test_event", "payload_value")
 
     h.assert_eq[USize](1, pending.size())
     (let event, _) = pending(0)?
     h.assert_eq[String val]("test_event", event)
+
+// --- PubSub tests ---
+
+class \nodoc\ _TestPubSubDeliver is UnitTest
+  fun name(): String => "pub_sub/deliver"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    let receiver = _TestInfoReceiver(h)
+    let pub_sub = PubSub
+    pub_sub.subscribe("topic", receiver)
+    pub_sub.publish("topic", "hello")
+
+class \nodoc\ _TestPubSubNoSubscribers is UnitTest
+  fun name(): String => "pub_sub/no_subscribers"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    let pub_sub = PubSub
+    // Publishing to an empty topic should not crash
+    pub_sub.publish("empty_topic", "hello")
+    // Use a sentinel to prove the publish was processed
+    let receiver = _TestInfoReceiver(h)
+    pub_sub.subscribe("proof", receiver)
+    pub_sub.publish("proof", "done")
+
+class \nodoc\ _TestPubSubUnsubscribe is UnitTest
+  fun name(): String => "pub_sub/unsubscribe"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    let guarded = _GuardedInfoReceiver
+    let sentinel = _SentinelInfoReceiver(h, guarded)
+    let pub_sub = PubSub
+    pub_sub.subscribe("topic", guarded)
+    pub_sub.subscribe("topic", sentinel)
+    pub_sub.unsubscribe("topic", guarded)
+    pub_sub.publish("topic", "after_unsub")
+
+class \nodoc\ _TestPubSubUnsubscribeAll is UnitTest
+  fun name(): String => "pub_sub/unsubscribe_all"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    let guarded = _GuardedInfoReceiver
+    let sentinel = _SentinelInfoReceiver(h, guarded)
+    let pub_sub = PubSub
+    pub_sub.subscribe("topic_a", guarded)
+    pub_sub.subscribe("topic_b", guarded)
+    pub_sub.subscribe("topic_a", sentinel)
+    pub_sub.unsubscribe_all(guarded)
+    pub_sub.publish("topic_a", "after_unsub_all")
+
+class \nodoc\ _TestPubSubMultipleSubscribers is UnitTest
+  fun name(): String => "pub_sub/multiple_subscribers"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    let pub_sub = PubSub
+    let counter = _CountingInfoReceiver(h, 3)
+    // Subscribe three separate receivers; all should fire
+    let r1 = _ForwardingInfoReceiver(counter)
+    let r2 = _ForwardingInfoReceiver(counter)
+    let r3 = _ForwardingInfoReceiver(counter)
+    pub_sub.subscribe("topic", r1)
+    pub_sub.subscribe("topic", r2)
+    pub_sub.subscribe("topic", r3)
+    pub_sub.publish("topic", "broadcast")
+
+actor \nodoc\ _CountingInfoReceiver
+  """
+  Completes the test after receiving an expected number of forwarded
+  messages.
+  """
+  let _h: TestHelper
+  let _expected: USize
+  var _count: USize = 0
+
+  new create(h: TestHelper, expected: USize) =>
+    _h = h
+    _expected = expected
+
+  be received() =>
+    _count = _count + 1
+    if _count == _expected then
+      _h.complete(true)
+    end
+
+actor \nodoc\ _ForwardingInfoReceiver is InfoReceiver
+  """
+  Forwards each info message to a CountingInfoReceiver.
+  """
+  let _counter: _CountingInfoReceiver tag
+
+  new create(counter: _CountingInfoReceiver tag) =>
+    _counter = counter
+
+  be info(message: Any val) =>
+    _counter.received()
+
+// --- Socket + PubSub integration tests ---
+
+class \nodoc\ _TestSocketSubscribeDeliver is UnitTest
+  fun name(): String => "socket/subscribe_deliver"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    let assigns = Assigns
+    let pending = Array[(String val, json.JsonValue)]
+    let receiver = _TestInfoReceiver(h)
+    let pub_sub = PubSub
+    let socket = Socket(assigns, pending, receiver, pub_sub)
+    socket.subscribe("test_topic")
+    pub_sub.publish("test_topic", "hello")

--- a/livery/info_receiver.pony
+++ b/livery/info_receiver.pony
@@ -1,0 +1,9 @@
+interface tag InfoReceiver
+  """
+  A handle for sending messages to a LiveView connection.
+
+  External actors use this to deliver messages that arrive via
+  `LiveView.handle_info`. Obtain a reference by calling `Socket.self()`
+  inside a lifecycle method.
+  """
+  be info(message: Any val)

--- a/livery/listener.pony
+++ b/livery/listener.pony
@@ -12,14 +12,16 @@ actor Listener is lori.TCPListenerActor
   let _server_auth: lori.TCPServerAuth
   let _config: mare.WebSocketConfig val
   let _routes: Routes val
+  let _pub_sub: PubSub tag
   let _out: OutStream tag
 
   new create(auth: lori.TCPListenAuth, host: String, port: String,
-    routes: Routes val, out: OutStream tag)
+    routes: Routes val, pub_sub: PubSub tag, out: OutStream tag)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = mare.WebSocketConfig(host, port)
     _routes = routes
+    _pub_sub = pub_sub
     _out = out
     _tcp_listener = lori.TCPListener(auth, host, port, this)
 
@@ -27,7 +29,7 @@ actor Listener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _Connection =>
-    _Connection(_server_auth, fd, _config, _routes)
+    _Connection(_server_auth, fd, _config, _routes, _pub_sub)
 
   fun ref _on_listen_failure() =>
     _out.print("Listener: failed to bind to " + _config.host + ":"

--- a/livery/live_view.pony
+++ b/livery/live_view.pony
@@ -27,6 +27,16 @@ trait LiveView
     automatically if any assigns changed.
     """
 
+  fun ref handle_info(message: Any val, socket: Socket ref) =>
+    """
+    Called when an external actor sends a message to this connection
+    via PubSub or direct `InfoReceiver.info` calls.
+
+    Default implementation does nothing. Override to handle server-push
+    messages from timers, background jobs, or PubSub topics.
+    """
+    None
+
   fun box render(assigns: Assigns box): String ?
     """
     Return the full HTML for the current state. Partial because rendering

--- a/livery/livery.pony
+++ b/livery/livery.pony
@@ -8,16 +8,29 @@ Define server-side view logic by implementing the `LiveView` trait:
 
 - `mount` initializes state on the `Socket`
 - `handle_event` responds to client interactions
+- `handle_info` receives server-push messages from external actors
 - `render` produces HTML from the current `Assigns`
 
 Use `HtmlTemplate` from the templates library for rendering — it auto-escapes
 dynamic values by default.
 
+## Server Push
+
+External actors can send messages to a connection through `PubSub` or
+directly via `InfoReceiver`. Messages arrive at `LiveView.handle_info`,
+where the view can update assigns and trigger a re-render.
+
+- Call `Socket.self()` in a lifecycle method to get a shareable
+  `InfoReceiver` handle
+- Call `Socket.subscribe(topic)` to receive messages from a PubSub topic
+- Subscriptions are automatically cleaned up when the connection closes
+
 ## Getting Started
 
 1. Implement the `LiveView` trait on a class
 2. Register routes via `Router` and freeze with `Router.build()`
-3. Start a `Listener` with your routes
+3. Create a `PubSub` instance
+4. Start a `Listener` with your routes and PubSub
 
-See the examples directory for a working counter application.
+See the examples directory for working applications.
 """

--- a/livery/pub_sub.pony
+++ b/livery/pub_sub.pony
@@ -1,0 +1,55 @@
+use collections = "collections"
+
+actor PubSub
+  """
+  Topic-based publish-subscribe for delivering messages to LiveView
+  connections.
+
+  Create a PubSub instance and pass it to `Listener`. LiveViews subscribe
+  via `Socket.subscribe(topic)`. External actors publish via
+  `pub_sub.publish(topic, message)`, which delivers to all current
+  subscribers via `InfoReceiver.info`.
+  """
+  let _topics: collections.Map[String, collections.SetIs[InfoReceiver tag]]
+
+  new create() =>
+    _topics = collections.Map[String, collections.SetIs[InfoReceiver tag]]
+
+  be subscribe(topic: String, subscriber: InfoReceiver tag) =>
+    """
+    Add a subscriber to a topic. Idempotent — subscribing the same
+    connection to the same topic twice has no additional effect.
+    """
+    let subs = try
+      _topics(topic)?
+    else
+      let s = collections.SetIs[InfoReceiver tag]
+      _topics(topic) = s
+      s
+    end
+    subs.set(subscriber)
+
+  be unsubscribe(topic: String, subscriber: InfoReceiver tag) =>
+    """
+    Remove a subscriber from a topic.
+    """
+    try _topics(topic)?.unset(subscriber) end
+
+  be unsubscribe_all(subscriber: InfoReceiver tag) =>
+    """
+    Remove a subscriber from all topics. Called automatically by the
+    connection actor when a WebSocket closes.
+    """
+    for subs in _topics.values() do
+      subs.unset(subscriber)
+    end
+
+  be publish(topic: String, message: Any val) =>
+    """
+    Send a message to all subscribers of a topic.
+    """
+    try
+      for subscriber in _topics(topic)?.values() do
+        subscriber.info(message)
+      end
+    end

--- a/livery/socket.pony
+++ b/livery/socket.pony
@@ -6,16 +6,22 @@ class Socket
   User-facing API passed to `LiveView` lifecycle methods.
 
   Wraps assigns and provides framework actions like pushing server-initiated
-  events to the client.
+  events to the client, subscribing to PubSub topics, and obtaining a
+  shareable connection reference.
   """
   let _assigns: Assigns ref
   let _pending_events: Array[(String val, json.JsonValue)] ref
+  let _self: InfoReceiver tag
+  let _pub_sub: PubSub tag
 
   new create(assigns: Assigns ref,
-    pending_events: Array[(String val, json.JsonValue)] ref)
+    pending_events: Array[(String val, json.JsonValue)] ref,
+    self': InfoReceiver tag, pub_sub: PubSub tag)
   =>
     _assigns = assigns
     _pending_events = pending_events
+    _self = self'
+    _pub_sub = pub_sub
 
   fun ref assign(key: String,
     value: (String | templates.TemplateValue))
@@ -38,3 +44,26 @@ class Socket
     flushed after the current render cycle.
     """
     _pending_events.push((event, payload))
+
+  fun box self(): InfoReceiver tag =>
+    """
+    Return a shareable reference to this connection.
+
+    Pass this to external actors so they can send messages via
+    `InfoReceiver.info`, which arrive at `LiveView.handle_info`.
+    """
+    _self
+
+  fun ref subscribe(topic: String) =>
+    """
+    Subscribe this connection to a PubSub topic. Messages published to
+    the topic will arrive via `LiveView.handle_info`. Subscriptions are
+    automatically cleaned up when the connection closes.
+    """
+    _pub_sub.subscribe(topic, _self)
+
+  fun ref unsubscribe(topic: String) =>
+    """
+    Unsubscribe this connection from a PubSub topic.
+    """
+    _pub_sub.unsubscribe(topic, _self)


### PR DESCRIPTION
External actors can now send messages to LiveView connections through PubSub topics or direct InfoReceiver references. Messages arrive at the new `handle_info` lifecycle method, which can update assigns and trigger re-renders just like `handle_event`.

New public API:
- `InfoReceiver` — `interface tag` handle for sending messages to a connection
- `PubSub` — topic-based publish-subscribe actor
- `LiveView.handle_info` — lifecycle method for server-push messages (default no-op)
- `Socket.self()` — returns shareable `InfoReceiver tag` for the connection
- `Socket.subscribe(topic)` / `Socket.unsubscribe(topic)` — PubSub convenience methods

Connections auto-cleanup all PubSub subscriptions when the WebSocket closes. No new wire protocol messages — `handle_info` is server-side only, re-renders use the existing render message.

Includes a ticker example demonstrating PubSub-driven updates from an external timer actor.

Design: #6