### PR TITLE
Add push event demonstration to ticker example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ livery/           # Library package (also the test compilation target)
   _test.pony      # All tests (single runner)
 examples/
   counter/        # Increment/decrement counter
-  ticker/         # PubSub-driven ticker (server push)
+  ticker/         # PubSub-driven ticker (server push via re-render + push_event)
 client/           # JavaScript client library
   src/            # Source modules (wire, events, socket, live-view)
   test/           # vitest tests

--- a/client/test/live-view.test.js
+++ b/client/test/live-view.test.js
@@ -137,6 +137,90 @@ describe("LiveView", () => {
     expect(handler).toHaveBeenCalledWith({ count: 42 });
   });
 
+  it("does not throw on push with no handler registered", () => {
+    const lv = createLiveView();
+    lv.connect();
+    ws().simulateOpen();
+
+    expect(() => {
+      ws().simulateMessage('{"t":"push","e":"unknown","p":{"x":1}}');
+    }).not.toThrow();
+  });
+
+  it("fires push handler registered after connect", () => {
+    const lv = createLiveView();
+    lv.connect();
+    ws().simulateOpen();
+
+    const handler = vi.fn();
+    lv.on("late", handler);
+
+    ws().simulateMessage('{"t":"push","e":"late","p":{"val":"ok"}}');
+
+    expect(handler).toHaveBeenCalledWith({ val: "ok" });
+  });
+
+  it("dispatches multiple sequential push events to correct handlers", () => {
+    const lv = createLiveView();
+    const tickHandler = vi.fn();
+    const alertHandler = vi.fn();
+    lv.on("tick", tickHandler);
+    lv.on("alert", alertHandler);
+    lv.connect();
+    ws().simulateOpen();
+
+    ws().simulateMessage('{"t":"push","e":"tick","p":{"n":1}}');
+    ws().simulateMessage('{"t":"push","e":"alert","p":{"msg":"hi"}}');
+    ws().simulateMessage('{"t":"push","e":"tick","p":{"n":2}}');
+
+    expect(tickHandler).toHaveBeenCalledTimes(2);
+    expect(tickHandler).toHaveBeenNthCalledWith(1, { n: 1 });
+    expect(tickHandler).toHaveBeenNthCalledWith(2, { n: 2 });
+    expect(alertHandler).toHaveBeenCalledTimes(1);
+    expect(alertHandler).toHaveBeenCalledWith({ msg: "hi" });
+  });
+
+  it("overwrites previous handler when on() is called for same event", () => {
+    const lv = createLiveView();
+    const first = vi.fn();
+    const second = vi.fn();
+    lv.on("tick", first);
+    lv.on("tick", second);
+    lv.connect();
+    ws().simulateOpen();
+
+    ws().simulateMessage('{"t":"push","e":"tick","p":{"n":1}}');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith({ n: 1 });
+  });
+
+  it("preserves push handlers across reconnection", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const lv = createLiveView();
+    const handler = vi.fn();
+    lv.on("tick", handler);
+    lv.connect();
+    ws().simulateOpen();
+
+    ws().simulateMessage('{"t":"push","e":"tick","p":{"n":1}}');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Simulate unexpected close and reconnect
+    ws().simulateClose();
+    vi.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    ws().simulateOpen();
+    ws().simulateMessage('{"t":"push","e":"tick","p":{"n":2}}');
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(2, { n: 2 });
+
+    Math.random.mockRestore();
+  });
+
   it("does not throw on error messages", () => {
     const lv = createLiveView();
     lv.connect();

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,4 +40,4 @@ Implements a simple increment/decrement counter as a `LiveView`. Registers a sin
 
 ## [ticker](ticker/)
 
-Demonstrates server push via `PubSub` and `handle_info`. A `Ticker` actor publishes to the `"tick"` topic every second. The `TickerView` subscribes in `mount` and increments a counter each time `handle_info` fires. Shows how external actors drive LiveView updates without any client interaction.
+Demonstrates server push via `PubSub` and `handle_info`. A `Ticker` actor publishes to the `"tick"` topic every second. The `TickerView` subscribes in `mount` and increments a counter each time `handle_info` fires — this drives a re-render via assigns. It also calls `push_event` to send the raw tick count to the client, where a JavaScript `on()` handler updates a separate DOM element outside the LiveView container. Shows the two complementary push mechanisms: server-rendered DOM updates (assigns + re-render) and client-side event handling (`push_event` + `on()`).

--- a/examples/ticker/index.html
+++ b/examples/ticker/index.html
@@ -3,12 +3,18 @@
 <head><title>Ticker - Livery Example</title></head>
 <body>
   <div id="lv-root"></div>
+  <p id="push-log">Waiting for push events...</p>
   <script src="../../client/dist/livery.iife.js"></script>
   <script>
-    new LiveView({
+    var lv = new LiveView({
       url: "ws://localhost:8082/ticker",
       target: document.getElementById("lv-root")
-    }).connect();
+    });
+    lv.on("tick", function(payload) {
+      document.getElementById("push-log").textContent =
+        "Last push: timer tick #" + payload.timer_count;
+    });
+    lv.connect();
   </script>
 </body>
 </html>

--- a/examples/ticker/main.pony
+++ b/examples/ticker/main.pony
@@ -9,8 +9,11 @@ class TickerView is LiveView
   A LiveView that displays a count incremented by an external ticker.
 
   Subscribes to the `"tick"` PubSub topic in `mount`. Each time the
-  `Ticker` actor publishes to that topic, `handle_info` fires and
-  increments the counter.
+  `Ticker` actor publishes to that topic, `handle_info` fires,
+  increments the counter (triggering a re-render via assigns), and calls
+  `push_event` to send the raw tick count to the client. This
+  demonstrates both push mechanisms: server-rendered DOM updates and
+  client-side event handling via `on()`.
   """
   let _template: HtmlTemplate val
 
@@ -36,6 +39,10 @@ class TickerView is LiveView
     try
       let current = socket.get_assign("count")?.string()?.i64()?
       socket.assign("count", (current + 1).string())
+    end
+    match message
+    | let n: U64 =>
+      socket.push_event("tick", JsonObject.update("timer_count", n.i64()))
     end
 
   fun box render(assigns: Assigns box): String ? =>


### PR DESCRIPTION
Enhances the ticker example to call `push_event` alongside the existing assign-based re-render, demonstrating both server push mechanisms in one example. A JavaScript `on()` handler updates a `#push-log` element outside the LiveView container, showing client-side event handling independent of morphdom.

Adds 5 client-side tests for push event edge cases: no handler registered, late registration, multiple sequential events, handler overwrite, and handler survival across reconnection.

Design: #15