### PR TITLE
Add form handling with lv-change and lv-submit event bindings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ livery/           # Library package (also the test compilation target)
 examples/
   counter/        # Increment/decrement counter
   ticker/         # PubSub-driven ticker (server push via re-render + push_event)
+  form/           # Registration form with live validation (lv-change + lv-submit)
 client/           # JavaScript client library
   src/            # Source modules (wire, events, socket, live-view)
   test/           # vitest tests
@@ -93,7 +94,7 @@ make client-build
 | Module | Role |
 |--------|------|
 | `src/wire.js` | Wire protocol encode/decode, mirrors `_wire_protocol.pony` |
-| `src/events.js` | Event delegation (`lv-click`, `lv-value-*`) via single root listener |
+| `src/events.js` | Event delegation (`lv-click`, `lv-value-*`, `lv-change`, `lv-submit`) via single root listener |
 | `src/socket.js` | WebSocket wrapper with heartbeat (30s interval, 10s ack timeout) and reconnection (exponential backoff, 30s cap) |
 | `src/live-view.js` | Main orchestrator — connects Socket, morphdom, and event delegation |
 | `src/index.js` | Entry point, re-exports `LiveView` |

--- a/client/src/events.js
+++ b/client/src/events.js
@@ -1,9 +1,46 @@
 /**
+ * Collect all named form fields into a plain object.
+ *
+ * @param {HTMLFormElement} form
+ * @returns {object} { fieldName: value, ... }
+ */
+function collectFormData(form) {
+  const payload = {};
+  for (const [key, value] of new FormData(form)) {
+    payload[key] = value;
+  }
+  return payload;
+}
+
+/**
+ * Walk up the DOM from `el` to find an ancestor (or self) that has
+ * the given attribute, stopping before exiting `root`.
+ *
+ * @param {HTMLElement} el - Starting element
+ * @param {HTMLElement} root - Boundary (exclusive)
+ * @param {string} attr - Attribute name to search for
+ * @returns {HTMLElement|null}
+ */
+function findAncestorWithAttr(el, root, attr) {
+  while (el && el !== root.parentNode) {
+    if (el.hasAttribute && el.hasAttribute(attr)) {
+      return el;
+    }
+    el = el.parentNode;
+  }
+  return null;
+}
+
+/**
  * Set up event delegation on a root element.
  *
- * Listens for clicks and walks up the DOM from the target to find
- * elements with `lv-click` attributes. Collects `lv-value-*` attributes
- * from the matched element into a payload object.
+ * Listens for clicks, form input changes, and form submissions. Walks up
+ * the DOM from the target to find elements with `lv-click`, `lv-change`,
+ * or `lv-submit` attributes.
+ *
+ * - `lv-click`: collects `lv-value-*` attributes into the payload
+ * - `lv-change`: collects all named form fields into the payload
+ * - `lv-submit`: prevents default submission, collects all named form fields
  *
  * @param {HTMLElement} root - Container element for delegation
  * @param {function(string, object): void} sendEvent - Called with (eventName, payload)
@@ -29,11 +66,30 @@ export function setupEventDelegation(root, sendEvent) {
     }
   }
 
+  function handleInput(event) {
+    const form = findAncestorWithAttr(event.target, root, "lv-change");
+    if (form) {
+      sendEvent(form.getAttribute("lv-change"), collectFormData(form));
+    }
+  }
+
+  function handleSubmit(event) {
+    const form = findAncestorWithAttr(event.target, root, "lv-submit");
+    if (form) {
+      event.preventDefault();
+      sendEvent(form.getAttribute("lv-submit"), collectFormData(form));
+    }
+  }
+
   root.addEventListener("click", handleClick);
+  root.addEventListener("input", handleInput);
+  root.addEventListener("submit", handleSubmit);
 
   return {
     destroy() {
       root.removeEventListener("click", handleClick);
+      root.removeEventListener("input", handleInput);
+      root.removeEventListener("submit", handleSubmit);
     },
   };
 }

--- a/client/test/events.test.js
+++ b/client/test/events.test.js
@@ -85,4 +85,123 @@ describe("setupEventDelegation", () => {
 
     expect(sendEvent).not.toHaveBeenCalled();
   });
+
+  it("lv-change fires sendEvent with form field values on input", () => {
+    const root = createRoot(
+      '<form lv-change="validate"><input name="username" value="alice" /></form>'
+    );
+    const sendEvent = vi.fn();
+    setupEventDelegation(root, sendEvent);
+
+    root.querySelector("input").dispatchEvent(
+      new Event("input", { bubbles: true })
+    );
+
+    expect(sendEvent).toHaveBeenCalledWith("validate", { username: "alice" });
+  });
+
+  it("lv-change collects all named fields in the form", () => {
+    const root = createRoot(
+      '<form lv-change="validate">' +
+        '<input name="username" value="bob" />' +
+        '<input name="email" value="bob@test.com" />' +
+      "</form>"
+    );
+    const sendEvent = vi.fn();
+    setupEventDelegation(root, sendEvent);
+
+    root.querySelector('input[name="username"]').dispatchEvent(
+      new Event("input", { bubbles: true })
+    );
+
+    expect(sendEvent).toHaveBeenCalledWith("validate", {
+      username: "bob",
+      email: "bob@test.com",
+    });
+  });
+
+  it("lv-change does not fire for inputs outside a form with lv-change", () => {
+    const root = createRoot(
+      '<form><input name="field" value="x" /></form>'
+    );
+    const sendEvent = vi.fn();
+    setupEventDelegation(root, sendEvent);
+
+    root.querySelector("input").dispatchEvent(
+      new Event("input", { bubbles: true })
+    );
+
+    expect(sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("lv-submit fires sendEvent with all form data", () => {
+    const root = createRoot(
+      '<form lv-submit="register">' +
+        '<input name="username" value="alice" />' +
+        '<input name="email" value="alice@test.com" />' +
+      "</form>"
+    );
+    const sendEvent = vi.fn();
+    setupEventDelegation(root, sendEvent);
+
+    root.querySelector("form").dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true })
+    );
+
+    expect(sendEvent).toHaveBeenCalledWith("register", {
+      username: "alice",
+      email: "alice@test.com",
+    });
+  });
+
+  it("lv-submit prevents default form submission", () => {
+    const root = createRoot(
+      '<form lv-submit="register"><input name="f" value="v" /></form>'
+    );
+    const sendEvent = vi.fn();
+    setupEventDelegation(root, sendEvent);
+
+    const event = new Event("submit", { bubbles: true, cancelable: true });
+    const preventSpy = vi.spyOn(event, "preventDefault");
+    root.querySelector("form").dispatchEvent(event);
+
+    expect(preventSpy).toHaveBeenCalled();
+  });
+
+  it("lv-submit does not fire for forms without lv-submit", () => {
+    const root = createRoot(
+      '<form><input name="f" value="v" /></form>'
+    );
+    const sendEvent = vi.fn();
+    setupEventDelegation(root, sendEvent);
+
+    root.querySelector("form").dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true })
+    );
+
+    expect(sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("destroy removes change and submit listeners along with click", () => {
+    const root = createRoot(
+      '<form lv-change="validate" lv-submit="register">' +
+        '<input name="f" value="v" />' +
+        '<button lv-click="btn">Click</button>' +
+      "</form>"
+    );
+    const sendEvent = vi.fn();
+    const { destroy } = setupEventDelegation(root, sendEvent);
+
+    destroy();
+
+    root.querySelector("input").dispatchEvent(
+      new Event("input", { bubbles: true })
+    );
+    root.querySelector("form").dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true })
+    );
+    root.querySelector("button").click();
+
+    expect(sendEvent).not.toHaveBeenCalled();
+  });
 });

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ make ssl=openssl_3.0.x examples
 |---------|---------|------|
 | counter | `./build/release/counter` | 8081 |
 | ticker | `./build/release/ticker` | 8082 |
+| form | `./build/release/form` | 8083 |
 
 1. Serve the repo root with a static file server (the HTML shells use relative paths to load the JS client bundle):
 
@@ -33,6 +34,7 @@ Then visit the example in your browser:
 
 - Counter: `http://localhost:8080/examples/counter/index.html`
 - Ticker: `http://localhost:8080/examples/ticker/index.html`
+- Form: `http://localhost:8080/examples/form/index.html`
 
 ## [counter](counter/)
 
@@ -41,3 +43,7 @@ Implements a simple increment/decrement counter as a `LiveView`. Registers a sin
 ## [ticker](ticker/)
 
 Demonstrates server push via `PubSub` and `handle_info`. A `Ticker` actor publishes to the `"tick"` topic every second. The `TickerView` subscribes in `mount` and increments a counter each time `handle_info` fires — this drives a re-render via assigns. It also calls `push_event` to send the raw tick count to the client, where a JavaScript `on()` handler updates a separate DOM element outside the LiveView container. Shows the two complementary push mechanisms: server-rendered DOM updates (assigns + re-render) and client-side event handling (`push_event` + `on()`).
+
+## [form](form/)
+
+Demonstrates form handling with live validation. A registration form uses `lv-change` for real-time field validation as the user types and `lv-submit` for full validation on submit. Field values and error messages are stored as assigns — the template renders both the current input values and per-field error messages. Shows how the existing `handle_event` API handles form data without any additional library types: the client serializes form fields as a JSON payload, and the server extracts them with `JsonNav`.

--- a/examples/form/index.html
+++ b/examples/form/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head><title>Form - Livery Example</title></head>
+<body>
+  <div id="lv-root"></div>
+  <script src="../../client/dist/livery.iife.js"></script>
+  <script>
+    new LiveView({
+      url: "ws://localhost:8083/form",
+      target: document.getElementById("lv-root")
+    }).connect();
+  </script>
+</body>
+</html>

--- a/examples/form/main.pony
+++ b/examples/form/main.pony
@@ -1,0 +1,123 @@
+use "templates"
+use "json"
+use lori = "lori"
+use "../../livery"
+
+class FormView is LiveView
+  """
+  A LiveView that demonstrates form handling with live validation.
+
+  Uses `lv-change` for real-time field validation as the user types and
+  `lv-submit` for full form validation on submit. Field values and error
+  messages are stored as assigns and rendered via the template.
+  """
+  let _template: HtmlTemplate val
+
+  new create() ? =>
+    _template = HtmlTemplate.parse(
+      """
+      <div>
+        <h1>Register</h1>
+        <form lv-change="validate" lv-submit="register">
+          <div>
+            <label>Username</label>
+            <input type="text" name="username" value="{{ username }}" />
+            <span style="color:red">{{ username_error }}</span>
+          </div>
+          <div>
+            <label>Email</label>
+            <input type="text" name="email" value="{{ email }}" />
+            <span style="color:red">{{ email_error }}</span>
+          </div>
+          <div>
+            <label>Password</label>
+            <input type="password" name="password" value="{{ password }}" />
+            <span style="color:red">{{ password_error }}</span>
+          </div>
+          <button type="submit">Register</button>
+        </form>
+        <p style="color:green">{{ result }}</p>
+      </div>
+      """)?
+
+  fun ref mount(socket: Socket ref) =>
+    socket.assign("username", "")
+    socket.assign("email", "")
+    socket.assign("password", "")
+    socket.assign("username_error", "")
+    socket.assign("email_error", "")
+    socket.assign("password_error", "")
+    socket.assign("result", "")
+
+  fun ref handle_event(event: String val, payload: JsonValue,
+    socket: Socket ref)
+  =>
+    let nav = JsonNav(payload)
+    try
+      let username = nav("username").as_string()?
+      let email = nav("email").as_string()?
+      let password = nav("password").as_string()?
+
+      socket.assign("username", username)
+      socket.assign("email", email)
+      socket.assign("password", password)
+
+      match event
+      | "validate" =>
+        // Only validate non-empty fields during typing
+        socket.assign("username_error",
+          if (username.size() > 0) and (username.size() < 3) then
+            "Username must be at least 3 characters"
+          else "" end)
+        socket.assign("email_error",
+          if (email.size() > 0) and (not email.contains("@")) then
+            "Email must contain @"
+          else "" end)
+        socket.assign("password_error",
+          if (password.size() > 0) and (password.size() < 8) then
+            "Password must be at least 8 characters"
+          else "" end)
+        socket.assign("result", "")
+      | "register" =>
+        // Validate all fields including required checks
+        let username_err =
+          if username.size() == 0 then "Username is required"
+          elseif username.size() < 3 then
+            "Username must be at least 3 characters"
+          else "" end
+        let email_err =
+          if email.size() == 0 then "Email is required"
+          elseif not email.contains("@") then "Email must contain @"
+          else "" end
+        let password_err =
+          if password.size() == 0 then "Password is required"
+          elseif password.size() < 8 then
+            "Password must be at least 8 characters"
+          else "" end
+
+        socket.assign("username_error", username_err)
+        socket.assign("email_error", email_err)
+        socket.assign("password_error", password_err)
+
+        if (username_err == "") and (email_err == "")
+          and (password_err == "")
+        then
+          socket.assign("result",
+            "Registration successful for " + username + "!")
+        else
+          socket.assign("result", "")
+        end
+      end
+    end
+
+  fun box render(assigns: Assigns box): String ? =>
+    _template.render(assigns.template_values())?
+
+actor Main
+  new create(env: Env) =>
+    let router = Router
+    router.route("/form",
+      {(): LiveView ref^ ? => FormView.create()?} val)
+
+    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8083",
+      router.build(), PubSub, env.err)

--- a/livery/live_view.pony
+++ b/livery/live_view.pony
@@ -22,7 +22,8 @@ trait LiveView
   fun ref handle_event(event: String val, payload: json.JsonValue,
     socket: Socket ref)
     """
-    Called when the client sends a UI event (e.g., a button click). Use
+    Called when the client sends a UI event (e.g., a button click or form
+    change/submission). Use
     `socket.assign()` to update state — the framework re-renders
     automatically if any assigns changed.
     """

--- a/livery/livery.pony
+++ b/livery/livery.pony
@@ -25,6 +25,30 @@ where the view can update assigns and trigger a re-render.
 - Call `Socket.subscribe(topic)` to receive messages from a PubSub topic
 - Subscriptions are automatically cleaned up when the connection closes
 
+## Forms
+
+Form handling works through the existing `handle_event` API — no additional
+library types are needed. The JavaScript client sends form field data as a
+JSON object payload via `lv-change` (fires on every keystroke for real-time
+validation) and `lv-submit` (fires on form submission).
+
+On the server, extract fields with `JsonNav` and validate:
+
+```pony
+fun ref handle_event(event: String val, payload: json.JsonValue,
+  socket: Socket ref)
+=>
+  let nav = json.JsonNav(payload)
+  try
+    let username = nav("username").as_string()?
+    let email = nav("email").as_string()?
+    // validate and assign errors
+  end
+```
+
+Store field values and error messages as assigns so the template renders both
+the current input values and per-field feedback.
+
 ## Getting Started
 
 1. Implement the `LiveView` trait on a class


### PR DESCRIPTION
Phase 3 of the livery design (Discussion #3, plan in Discussion #10). Adds form handling through the existing `handle_event` API — no new library types needed.

**Client side**: Two new event bindings in `events.js` — `lv-change` (fires on `input` events, collects all named form fields via `FormData`) and `lv-submit` (fires on `submit` events with `preventDefault`, same payload). Both use ancestor walk-up to find the `<form>` element with the binding attribute.

**Server side**: No library changes required. New `examples/form/` demonstrates the pattern — a registration form with real-time validation (`lv-change` validates non-empty fields as the user types) and full validation on submit (`lv-submit` checks required fields). Uses `JsonNav` for field extraction.

**Documentation**: Package docstring updated with a Forms section showing the pattern. Examples README, CLAUDE.md file layout, and `handle_event` method docstring updated.