### PR TITLE
Update mare to 0.3.0 and hobby to 0.7.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,8 @@
+
+## Fix potential connection hang when timer event subscription fails
+
+On some platforms, if the operating system cannot allocate resources for a connection timer (e.g., ENOMEM on kqueue or epoll), connections could hang silently instead of reporting an error. Timer subscription failures are now detected and reported as connection failures.
+
+## Require ponyc 0.63.1 or later
+
+livery now requires ponyc 0.63.1 or later. Older ponyc versions are no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix potential connection hang when timer event subscription fails ([PR #44](https://github.com/ponylang/livery/pull/44))
 
 ### Added
 
 
 ### Changed
 
+- Require ponyc 0.63.1 or later ([PR #44](https://github.com/ponylang/livery/pull/44))
 
 ## [0.1.4] - 2026-04-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ Targets: `make test` (build + run tests + build examples), `make unit-tests` (te
 
 | Package | Version | Use path | Role |
 |---------|---------|----------|------|
-| mare | 0.2.4 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
+| mare | 0.3.0 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
 | templates | 0.3.2 | `"templates"` | HTML rendering (`HtmlTemplate` auto-escapes by default, `TemplateValues.scope()` for child scopes, `TemplateSink`/`render_to()` for split rendering) |
-| hobby | 0.6.1 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
+| hobby | 0.7.0 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
 | lori | (transitive via mare) | `"lori"` | TCP networking, idle timeout |
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Livery is beta quality software that will change frequently. Expect breaking cha
 
 ## Installation
 
+* Requires ponyc 0.63.1 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/livery.git --version 0.1.4`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/mare.git",
-      "version": "0.2.4"
+      "version": "0.3.0"
     },
     {
       "locator": "github.com/ponylang/templates.git",
@@ -21,7 +21,7 @@
     },
     {
       "locator": "github.com/ponylang/hobby.git",
-      "version": "0.6.1"
+      "version": "0.7.0"
     }
   ]
 }


### PR DESCRIPTION
Picks up ASIO_ERROR handling for timer subscription failures and requires ponyc 0.63.1 or later.