### PR TITLE
Require ponyc 0.64.0 or later

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.release-notes/require-ponyc-0.64.0.md
+++ b/.release-notes/require-ponyc-0.64.0.md
@@ -1,0 +1,5 @@
+## Require ponyc 0.64.0 or later
+
+livery now requires ponyc 0.64.0 or later. The previous minimum was 0.63.1.
+
+This is driven by updates to mare 0.4.0 and hobby 0.8.0, which transitively require ponyc 0.64.0 via lori 0.15.0 for changes to FFI declaration syntax and the runtime socket API. Older ponyc versions will fail to compile livery.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ Targets: `make test` (build + run tests + build examples), `make unit-tests` (te
 
 | Package | Version | Use path | Role |
 |---------|---------|----------|------|
-| mare | 0.3.0 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
+| mare | 0.4.0 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
 | templates | 0.3.2 | `"templates"` | HTML rendering (`HtmlTemplate` auto-escapes by default, `TemplateValues.scope()` for child scopes, `TemplateSink`/`render_to()` for split rendering) |
-| hobby | 0.7.0 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
+| hobby | 0.8.0 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
 | lori | (transitive via mare) | `"lori"` | TCP networking, idle timeout |
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Livery is beta quality software that will change frequently. Expect breaking cha
 
 ## Installation
 
-* Requires ponyc 0.63.1 or later
+* Requires ponyc 0.64.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/livery.git --version 0.2.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/mare.git",
-      "version": "0.3.0"
+      "version": "0.4.0"
     },
     {
       "locator": "github.com/ponylang/templates.git",
@@ -21,7 +21,7 @@
     },
     {
       "locator": "github.com/ponylang/hobby.git",
-      "version": "0.7.0"
+      "version": "0.8.0"
     }
   ]
 }


### PR DESCRIPTION
Updates livery to use mare 0.4.0 and hobby 0.8.0, which transitively require ponyc 0.64.0 via lori 0.15.0. Switches CI workflows that pull `shared-docker-ci-standard-builder-with-libressl-4.2.1` and `library-documentation-action-v2` from the `:release` channel to `:nightly` so they can build against the soon-to-be-released ponyc 0.64.0.

Will need a follow-up to switch back to `:release` once ponyc 0.64.0 ships (tracked in ponylang/ponyc#5298).