### PR TITLE
Fix compilation against ponyc 0.65.0

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.release-notes/fix-compilation-against-ponyc-0.65.0.md
+++ b/.release-notes/fix-compilation-against-ponyc-0.65.0.md
@@ -1,0 +1,5 @@
+## Fix compilation against ponyc 0.65.0
+
+livery now requires ponyc 0.65.0 or later. The previous minimum was 0.64.0.
+
+ponyc 0.65.0 includes breaking changes to the standard library's json package that livery uses to encode and decode the WebSocket wire protocol. livery has been updated for the new json API; older ponyc versions will fail to compile livery.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Livery is beta quality software that will change frequently. Expect breaking cha
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later
+* Requires ponyc 0.65.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/livery.git --version 0.3.0`
 * `corral fetch` to fetch your dependencies

--- a/livery/_test.pony
+++ b/livery/_test.pony
@@ -300,7 +300,7 @@ class \nodoc\ _TestDecodeEvent is UnitTest
       .update("t", "event")
       .update("e", "increment")
       .update("p", json.JsonObject.update("value", "5"))
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | let msg: _EventMessage =>
@@ -328,7 +328,7 @@ class \nodoc\ _TestDecodeHeartbeat is UnitTest
   fun apply(h: TestHelper) =>
     let data = json.JsonObject
       .update("t", "heartbeat")
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | _HeartbeatMessage => None
@@ -353,7 +353,7 @@ class \nodoc\ _TestDecodeMissingType is UnitTest
   fun apply(h: TestHelper) =>
     let data = json.JsonObject
       .update("e", "increment")
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | let err: _WireError =>
@@ -368,7 +368,7 @@ class \nodoc\ _TestDecodeUnknownType is UnitTest
   fun apply(h: TestHelper) =>
     let data = json.JsonObject
       .update("t", "bogus")
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | let err: _WireError =>
@@ -1007,7 +1007,7 @@ class \nodoc\ _TestDecodeEventWithTarget is UnitTest
       .update("e", "toggle")
       .update("p", json.JsonObject.update("id", "3"))
       .update("c", "todo-3")
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | let msg: _EventMessage =>
@@ -1028,7 +1028,7 @@ class \nodoc\ _TestDecodeEventWithoutTarget is UnitTest
       .update("t", "event")
       .update("e", "click")
       .update("p", None)
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | let msg: _EventMessage =>
@@ -1050,7 +1050,7 @@ class \nodoc\ _TestDecodeEventNonStringTarget is UnitTest
       .update("e", "click")
       .update("p", None)
       .update("c", I64(42))
-      .string()
+      .print()
 
     match _WireProtocol.decode_client_message(consume data)
     | let err: _WireError =>

--- a/livery/_wire_protocol.pony
+++ b/livery/_wire_protocol.pony
@@ -11,7 +11,7 @@ primitive _WireProtocol
     json.JsonObject
       .update("t", "render")
       .update("html", html)
-      .string()
+      .print()
 
   fun encode_render_full(statics: Array[String] val,
     dynamics: Array[String] val): String val
@@ -32,7 +32,7 @@ primitive _WireProtocol
       .update("t", "render_full")
       .update("s", s_arr)
       .update("d", d_arr)
-      .string()
+      .print()
 
   fun encode_render_diff(
     changes: Array[(USize, String)] val): String val
@@ -48,7 +48,7 @@ primitive _WireProtocol
     json.JsonObject
       .update("t", "render_diff")
       .update("d", d_obj)
-      .string()
+      .print()
 
   fun encode_heartbeat_ack(): String val =>
     """
@@ -56,7 +56,7 @@ primitive _WireProtocol
     """
     json.JsonObject
       .update("t", "heartbeat_ack")
-      .string()
+      .print()
 
   fun encode_push_event(event: String val, payload: json.JsonValue)
     : String val
@@ -68,7 +68,7 @@ primitive _WireProtocol
       .update("t", "push")
       .update("e", event)
       .update("p", payload)
-      .string()
+      .print()
 
   fun encode_error(reason: String val): String val =>
     """
@@ -77,7 +77,7 @@ primitive _WireProtocol
     json.JsonObject
       .update("t", "error")
       .update("reason", reason)
-      .string()
+      .print()
 
   fun decode_client_message(data: String val)
     : (_ClientMessage | _WireError)


### PR DESCRIPTION
ponyc 0.65.0 renames the standard library json package's serialization methods (`JsonObject`/`JsonArray` `string()` -> `print()`). livery uses these to encode and decode the WebSocket wire protocol, so it no longer compiles against the new API. This updates the wire protocol to `print()` and bumps the minimum ponyc to 0.65.0.

Because the json change is only available on nightly until 0.65.0 ships, the workflows that compile livery (`pr`, `generate-documentation`, `release`) temporarily move to the nightly builder images. Switching them back to release is tracked as a post-release task on ponylang/ponyc#5392.