### PR TITLE
Update SSR example's hobby dependency to 0.8.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Targets: `make test` (build + run tests + build examples), `make unit-tests` (te
 |---------|---------|----------|------|
 | mare | 0.4.0 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
 | templates | 0.3.2 | `"templates"` | HTML rendering (`HtmlTemplate` auto-escapes by default, `TemplateValues.scope()` for child scopes, `TemplateSink`/`render_to()` for split rendering) |
-| hobby | 0.8.0 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
+| hobby | 0.8.1 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
 | lori | (transitive via mare) | `"lori"` | TCP networking, idle timeout |
 
 ## Architecture

--- a/corral.json
+++ b/corral.json
@@ -21,7 +21,7 @@
     },
     {
       "locator": "github.com/ponylang/hobby.git",
-      "version": "0.8.0"
+      "version": "0.8.1"
     }
   ]
 }


### PR DESCRIPTION
Bumps the hobby dependency from 0.8.0 to 0.8.1. hobby is used only by the SSR example (server-rendered first paint); the library itself doesn't depend on it. 0.8.1 required no API changes — the example compiles unchanged.

Not user-facing, so no release notes.