### PR TITLE
Fix connections going silent or truncating output under load

### DIFF
--- a/.release-notes/fix-connection-reliability-under-load.md
+++ b/.release-notes/fix-connection-reliability-under-load.md
@@ -1,0 +1,3 @@
+## Fix connections going silent or truncating output under load
+
+Several connection-reliability problems are fixed. A WebSocket connection could stop receiving client messages after the server pushed a large update; an HTTP connection could stop handling further requests after a large response; and a streamed HTTP response to a slow client could be truncated. In each case no error was raised — the connection simply went quiet or cut its output short, even while the peer was still active. Connections now keep delivering data reliably under these conditions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ Targets: `make test` (build + run tests + build examples), `make unit-tests` (te
 
 | Package | Version | Use path | Role |
 |---------|---------|----------|------|
-| mare | 0.4.0 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
+| mare | 0.4.1 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
 | templates | 0.3.2 | `"templates"` | HTML rendering (`HtmlTemplate` auto-escapes by default, `TemplateValues.scope()` for child scopes, `TemplateSink`/`render_to()` for split rendering) |
-| hobby | 0.8.1 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
+| hobby | 0.8.3 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
 | lori | (transitive via mare) | `"lori"` | TCP networking, idle timeout |
 
 ## Architecture

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/mare.git",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "locator": "github.com/ponylang/templates.git",
@@ -21,7 +21,7 @@
     },
     {
       "locator": "github.com/ponylang/hobby.git",
-      "version": "0.8.1"
+      "version": "0.8.3"
     }
   ]
 }


### PR DESCRIPTION
Updates mare to 0.4.1 and hobby to 0.8.3, picking up fixes for a WebSocket connection that could stop receiving messages after a large send, an HTTP connection that could go silent after a large response, and truncated streaming responses to slow clients.