### PR TITLE
Update mare to 0.5.1 and hobby to 0.9.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,7 @@
+## Fix connections closed mid-transfer by the idle timeout
+
+A connection could be closed by its idle timeout while it was still actively transferring data to a slow peer. A large update draining slowly to a slow client looked idle even though data was still moving, so it was closed mid-transfer. A connection is now closed by the idle timeout only when no data has moved in either direction for the timeout.
+
+## Drop support for Windows 10
+
+Building livery for Windows now requires ponyc 0.66.0 or later and Windows 11 or Windows Server 2022 or later. Windows 10 is no longer supported. Non-Windows platforms are unaffected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ Targets: `make test` (build + run tests + build examples), `make unit-tests` (te
 
 | Package | Version | Use path | Role |
 |---------|---------|----------|------|
-| mare | 0.4.1 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
+| mare | 0.5.1 | `"mare"` | WebSocket server (connection actor implements `WebSocketServerActor`) |
 | templates | 0.3.2 | `"templates"` | HTML rendering (`HtmlTemplate` auto-escapes by default, `TemplateValues.scope()` for child scopes, `TemplateSink`/`render_to()` for split rendering) |
-| hobby | 0.8.3 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
+| hobby | 0.9.0 | `"hobby"` | HTTP server (used in SSR example for dynamic first paint) |
 | lori | (transitive via mare) | `"lori"` | TCP networking, idle timeout |
 
 ## Architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix connections closed mid-transfer by the idle timeout ([PR #58](https://github.com/ponylang/livery/pull/58))
 
 ### Added
 
 
 ### Changed
+
+- Drop support for Windows 10 ([PR #58](https://github.com/ponylang/livery/pull/58))
 
 
 ## [0.4.0] - 2026-06-27

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Livery is beta quality software that will change frequently. Expect breaking cha
 
 ## Installation
 
-* Requires ponyc 0.65.0 or later
+* Requires ponyc 0.65.0 or later. On Windows, requires ponyc 0.66.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/livery.git --version 0.4.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/mare.git",
-      "version": "0.4.1"
+      "version": "0.5.1"
     },
     {
       "locator": "github.com/ponylang/templates.git",
@@ -21,7 +21,7 @@
     },
     {
       "locator": "github.com/ponylang/hobby.git",
-      "version": "0.8.3"
+      "version": "0.9.0"
     }
   ]
 }


### PR DESCRIPTION
Picks up mare's fix for connections cut off mid-transfer by the idle timeout, and drops Windows 10 support — building livery for Windows now requires ponyc 0.66.0 and Windows 11 / Server 2022 or later. Also bumps the hobby dependency used by the SSR example to 0.9.0.