### PR TITLE
Shuffle test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 test: unit-tests examples
 
 unit-tests: $(tests_binary)
-	$^ --exclude=integration --sequential
+	$^ --exclude=integration --sequential --shuffle
 
 test-one: $(tests_binary)
 	$^ --only="$(t)"


### PR DESCRIPTION
Add `--shuffle` to the test runs so tests execute in a randomized order, which surfaces hidden dependencies between tests.
