### PR TITLE
Add pony-lint

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -71,6 +72,10 @@ client-test: client-install
 client-build: client-install
 	docker run --rm -v "$$(pwd)/client:/app" -w /app node:22-slim npm run build
 
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
+
 TAGS:
 	ctags --recurse=yes $(SRC_DIR)
 
@@ -79,4 +84,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all examples clean TAGS test test-one client-install client-test client-build
+.PHONY: all examples clean lint TAGS test test-one client-install client-test client-build

--- a/examples/counter/counter.pony
+++ b/examples/counter/counter.pony
@@ -1,0 +1,3 @@
+"""
+Counter example for Livery.
+"""

--- a/examples/counter/main.pony
+++ b/examples/counter/main.pony
@@ -4,11 +4,15 @@ use lori = "lori"
 use "../../livery"
 
 class CounterView is LiveView
+  """
+  A LiveView that displays a counter with increment/decrement buttons.
+  """
   let _template: HtmlTemplate val
 
   new create() ? =>
-    _template = HtmlTemplate.parse(
-      """
+    _template =
+      HtmlTemplate.parse(
+        """
       <div>
         <h1>Count: {{ count }}</h1>
         <button lv-click="increment">+</button>
@@ -19,12 +23,15 @@ class CounterView is LiveView
   fun ref mount(socket: Socket ref) =>
     socket.assign("count", "0")
 
-  fun ref handle_event(event: String val, payload: JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: JsonValue,
     socket: Socket ref)
   =>
     try
       let current = socket.get_assign("count")?.string()?.i64()?
-      let next = match event
+      let next =
+        match event
         | "increment" => current + 1
         | "decrement" => current - 1
         else current
@@ -48,8 +55,14 @@ class CounterView is LiveView
 actor Main
   new create(env: Env) =>
     let router = Router
-    router.route("/counter",
-      {(): LiveView ref^ ? => CounterView.create()?} val)
+    router.route(
+      "/counter",
+      {(): LiveView ref^ ? => CounterView.create()? } val)
 
-    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8081",
-      router.build(), PubSub, env.err)
+    Listener(
+      lori.TCPListenAuth(env.root),
+      "0.0.0.0",
+      "8081",
+      router.build(),
+      PubSub,
+      env.err)

--- a/examples/form/form.pony
+++ b/examples/form/form.pony
@@ -1,0 +1,3 @@
+"""
+Form validation example for Livery.
+"""

--- a/examples/form/main.pony
+++ b/examples/form/main.pony
@@ -14,8 +14,9 @@ class FormView is LiveView
   let _template: HtmlTemplate val
 
   new create() ? =>
-    _template = HtmlTemplate.parse(
-      """
+    _template =
+      HtmlTemplate.parse(
+        """
       <div>
         <h1>Register</h1>
         <form lv-change="validate" lv-submit="register">
@@ -41,6 +42,9 @@ class FormView is LiveView
       """)?
 
   fun ref mount(socket: Socket ref) =>
+    """
+    Initialize form fields and error messages to empty strings.
+    """
     socket.assign("username", "")
     socket.assign("email", "")
     socket.assign("password", "")
@@ -49,7 +53,9 @@ class FormView is LiveView
     socket.assign("password_error", "")
     socket.assign("result", "")
 
-  fun ref handle_event(event: String val, payload: JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: JsonValue,
     socket: Socket ref)
   =>
     let nav = JsonNav(payload)
@@ -65,15 +71,18 @@ class FormView is LiveView
       match event
       | "validate" =>
         // Only validate non-empty fields during typing
-        socket.assign("username_error",
+        socket.assign(
+          "username_error",
           if (username.size() > 0) and (username.size() < 3) then
             "Username must be at least 3 characters"
           else "" end)
-        socket.assign("email_error",
+        socket.assign(
+          "email_error",
           if (email.size() > 0) and (not email.contains("@")) then
             "Email must contain @"
           else "" end)
-        socket.assign("password_error",
+        socket.assign(
+          "password_error",
           if (password.size() > 0) and (password.size() < 8) then
             "Password must be at least 8 characters"
           else "" end)
@@ -102,7 +111,8 @@ class FormView is LiveView
         if (username_err == "") and (email_err == "")
           and (password_err == "")
         then
-          socket.assign("result",
+          socket.assign(
+            "result",
             "Registration successful for " + username + "!")
         else
           socket.assign("result", "")
@@ -126,8 +136,14 @@ class FormView is LiveView
 actor Main
   new create(env: Env) =>
     let router = Router
-    router.route("/form",
-      {(): LiveView ref^ ? => FormView.create()?} val)
+    router.route(
+      "/form",
+      {(): LiveView ref^ ? => FormView.create()? } val)
 
-    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8083",
-      router.build(), PubSub, env.err)
+    Listener(
+      lori.TCPListenAuth(env.root),
+      "0.0.0.0",
+      "8083",
+      router.build(),
+      PubSub,
+      env.err)

--- a/examples/ssr/main.pony
+++ b/examples/ssr/main.pony
@@ -7,11 +7,15 @@ use stallion = "stallion"
 use "../../livery"
 
 class CounterView is LiveView
+  """
+  A LiveView that displays a counter with increment/decrement buttons.
+  """
   let _template: HtmlTemplate val
 
   new create() ? =>
-    _template = HtmlTemplate.parse(
-      """
+    _template =
+      HtmlTemplate.parse(
+        """
       <div>
         <h1>Count: {{ count }}</h1>
         <button lv-click="increment">+</button>
@@ -22,12 +26,15 @@ class CounterView is LiveView
   fun ref mount(socket: Socket ref) =>
     socket.assign("count", "0")
 
-  fun ref handle_event(event: String val, payload: JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: JsonValue,
     socket: Socket ref)
   =>
     try
       let current = socket.get_assign("count")?.string()?.i64()?
-      let next = match event
+      let next =
+        match event
         | "increment" => current + 1
         | "decrement" => current - 1
         else current
@@ -51,22 +58,30 @@ class CounterView is LiveView
 actor Main is hobby.ServerNotify
   new create(env: Env) =>
     let factory: Factory =
-      {(): LiveView ref^ ? => CounterView.create()?} val
+      {(): LiveView ref^ ? => CounterView.create()? } val
 
     // WebSocket server for live updates
     let router = Router
     router.route("/ssr", factory)
-    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8084",
-      router.build(), PubSub, env.err)
+    Listener(
+      lori.TCPListenAuth(env.root),
+      "0.0.0.0",
+      "8084",
+      router.build(),
+      PubSub,
+      env.err)
 
     // HTTP server for initial page load and static assets
     let client_root = FilePath(FileAuth(env.root), "client/dist")
     let app = hobby.Application
-      .>get("/", _index_handler(factory))
-      .>get("/client/*filepath", hobby.ServeFiles(client_root))
-    match app.build()
+      .> get("/", _index_handler(factory))
+      .> get("/client/*filepath", hobby.ServeFiles(client_root))
+    match \exhaustive\ app.build()
     | let built: hobby.BuiltApplication =>
-      hobby.Server(lori.TCPListenAuth(env.root), built, this
+      hobby.Server(
+        lori.TCPListenAuth(env.root),
+        built,
+        this
         where host = "0.0.0.0", port = "8085")
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
@@ -83,31 +98,32 @@ actor Main is hobby.ServerNotify
     """
     {(ctx)(factory) =>
       let handler = hobby.RequestHandler(consume ctx)
-      let body = match PageRenderer.render(factory)
-      | let html: String val =>
-        "<!DOCTYPE html>\n"
-          + "<html>\n"
-          + "<head><title>SSR Counter - Livery Example</title></head>\n"
-          + "<body>\n"
-          + "  <div id=\"lv-root\">" + html + "</div>\n"
-          + "  <script src=\"/client/livery.iife.js\"></script>\n"
-          + "  <script>\n"
-          + "    new LiveView({\n"
-          + "      url: \"ws://localhost:8084/ssr\",\n"
-          + "      target: document.getElementById(\"lv-root\")\n"
-          + "    }).connect();\n"
-          + "  </script>\n"
-          + "</body>\n"
-          + "</html>"
-      | let err: PageRenderError =>
-        handler.respond(stallion.StatusInternalServerError, err.string())
-        return
-      end
-      let headers = recover val
-        let h = stallion.Headers
-        h.set("Content-Type", "text/html; charset=utf-8")
-        h.set("Content-Length", body.size().string())
-        h
-      end
+      let body =
+        match \exhaustive\ PageRenderer.render(factory)
+        | let html: String val =>
+          "<!DOCTYPE html>\n"
+            + "<html>\n"
+            + "<head><title>SSR Counter - Livery Example</title></head>\n"
+            + "<body>\n"
+            + "  <div id=\"lv-root\">" + html + "</div>\n"
+            + "  <script src=\"/client/livery.iife.js\"></script>\n"
+            + "  <script>\n"
+            + "    new LiveView({\n"
+            + "      url: \"ws://localhost:8084/ssr\",\n"
+            + "      target: document.getElementById(\"lv-root\")\n"
+            + "    }).connect();\n"
+            + "  </script>\n"
+            + "</body>\n"
+            + "</html>"
+        | let err: PageRenderError =>
+          handler.respond(stallion.StatusInternalServerError, err.string())
+          return
+        end
+      let headers =
+        recover val
+          stallion.Headers
+            .> set("Content-Type", "text/html; charset=utf-8")
+            .> set("Content-Length", body.size().string())
+        end
       handler.respond_with_headers(stallion.StatusOK, headers, consume body)
     } val

--- a/examples/ssr/ssr.pony
+++ b/examples/ssr/ssr.pony
@@ -1,0 +1,3 @@
+"""
+Server-side rendering example for Livery.
+"""

--- a/examples/ticker/main.pony
+++ b/examples/ticker/main.pony
@@ -18,8 +18,9 @@ class TickerView is LiveView
   let _template: HtmlTemplate val
 
   new create() ? =>
-    _template = HtmlTemplate.parse(
-      """
+    _template =
+      HtmlTemplate.parse(
+        """
       <div>
         <h1>Ticks: {{ count }}</h1>
         <p>Count updates automatically every second.</p>
@@ -30,7 +31,9 @@ class TickerView is LiveView
     socket.assign("count", "0")
     socket.subscribe("tick")
 
-  fun ref handle_event(event: String val, payload: JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: JsonValue,
     socket: Socket ref)
   =>
     None
@@ -87,8 +90,14 @@ actor Main
     Ticker(pub_sub)
 
     let router = Router
-    router.route("/ticker",
-      {(): LiveView ref^ ? => TickerView.create()?} val)
+    router.route(
+      "/ticker",
+      {(): LiveView ref^ ? => TickerView.create()? } val)
 
-    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8082",
-      router.build(), pub_sub, env.err)
+    Listener(
+      lori.TCPListenAuth(env.root),
+      "0.0.0.0",
+      "8082",
+      router.build(),
+      pub_sub,
+      env.err)

--- a/examples/ticker/ticker.pony
+++ b/examples/ticker/ticker.pony
@@ -1,0 +1,3 @@
+"""
+Ticker example for Livery.
+"""

--- a/examples/todo/main.pony
+++ b/examples/todo/main.pony
@@ -12,16 +12,17 @@ class TodoItem is LiveComponent
   let _template: HtmlTemplate val
 
   new create() ? =>
-    _template = HtmlTemplate.parse(
-      """
-      <li>
-        <span class="{{ css_class }}">{{ text }}</span>
-        <button lv-click="toggle" lv-target="{{ id }}">
-          {{ toggle_label }}
-        </button>
-        <button lv-click="delete" lv-value-id="{{ id }}">Delete</button>
-      </li>
-      """)?
+    _template =
+      HtmlTemplate.parse(
+        """
+        <li>
+          <span class="{{ css_class }}">{{ text }}</span>
+          <button lv-click="toggle" lv-target="{{ id }}">
+            {{ toggle_label }}
+          </button>
+          <button lv-click="delete" lv-value-id="{{ id }}">Delete</button>
+        </li>
+        """)?
 
   fun ref mount(socket: ComponentSocket ref) =>
     None
@@ -33,7 +34,9 @@ class TodoItem is LiveComponent
       socket.assign("toggle_label", if done then "Undo" else "Done" end)
     end
 
-  fun ref handle_event(event: String val, payload: JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: JsonValue,
     socket: ComponentSocket ref)
   =>
     match event
@@ -41,16 +44,17 @@ class TodoItem is LiveComponent
       try
         let done = socket.get_assign("done")?.string()? == "true"
         socket.assign("done", if done then "false" else "true" end)
-        socket.assign("css_class",
+        socket.assign(
+          "css_class",
           if not done then "done" else "" end)
-        socket.assign("toggle_label",
+        socket.assign(
+          "toggle_label",
           if not done then "Undo" else "Done" end)
       end
     end
 
   fun box render(assigns: Assigns box): String ? =>
     _template.render(assigns.template_values())?
-
 
 class TodoListView is LiveView
   """
@@ -68,23 +72,26 @@ class TodoListView is LiveView
   var _todo_ids: Array[String] ref = Array[String]
 
   new create() ? =>
-    _template = HtmlTemplate.parse(
-      """
-      <div>
-        <h1>Todo List</h1>
-        <form lv-submit="add">
-          <input type="text" name="text" placeholder="Add a todo..." />
-          <button type="submit">Add</button>
-        </form>
-        <ul>{{ items_html }}</ul>
-        <p>{{ count }} items</p>
-      </div>
-      """)?
+    _template =
+      HtmlTemplate.parse(
+        """
+        <div>
+          <h1>Todo List</h1>
+          <form lv-submit="add">
+            <input type="text" name="text" placeholder="Add a todo..." />
+            <button type="submit">Add</button>
+          </form>
+          <ul>{{ items_html }}</ul>
+          <p>{{ count }} items</p>
+        </div>
+        """)?
 
   fun ref mount(socket: Socket ref) =>
     socket.assign("count", "0")
 
-  fun ref handle_event(event: String val, payload: JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: JsonValue,
     socket: Socket ref)
   =>
     match event
@@ -98,13 +105,13 @@ class TodoListView is LiveView
 
           let item = TodoItem.create()?
           if socket.register_component(id, item) then
-            socket.update_component(id,
+            socket.update_component(
+              id,
               recover val
-                let data = Array[(String, (String | TemplateValue))]
-                data.push(("id", id))
-                data.push(("text", text))
-                data.push(("done", "false"))
-                data
+                Array[(String, (String | TemplateValue))]
+                  .> push(("id", id))
+                  .> push(("text", text))
+                  .> push(("done", "false"))
               end)
             _todo_ids.push(id)
             socket.assign("count", _todo_ids.size().string())
@@ -149,12 +156,17 @@ class TodoListView is LiveView
       false
     end
 
-
 actor Main
   new create(env: Env) =>
     let router = Router
-    router.route("/todo",
-      {(): LiveView ref^ ? => TodoListView.create()?} val)
+    router.route(
+      "/todo",
+      {(): LiveView ref^ ? => TodoListView.create()? } val)
 
-    Listener(lori.TCPListenAuth(env.root), "0.0.0.0", "8086",
-      router.build(), PubSub, env.err)
+    Listener(
+      lori.TCPListenAuth(env.root),
+      "0.0.0.0",
+      "8086",
+      router.build(),
+      PubSub,
+      env.err)

--- a/examples/todo/todo.pony
+++ b/examples/todo/todo.pony
@@ -1,0 +1,3 @@
+"""
+Todo list example for Livery.
+"""

--- a/livery/_component_registry.pony
+++ b/livery/_component_registry.pony
@@ -73,7 +73,9 @@ class _ComponentRegistry
       entry.component.update(socket)
     end
 
-  fun ref handle_event(id: String, event: String val,
+  fun ref handle_event(
+    id: String,
+    event: String val,
     payload: json.JsonValue): Bool
   =>
     """
@@ -153,7 +155,6 @@ class _ComponentRegistry
     for (id, entry) in _entries.pairs() do
       assigns._set_component_html(id, entry.last_html)
     end
-
 
 class _ComponentEntry
   """

--- a/livery/_connection.pony
+++ b/livery/_connection.pony
@@ -22,8 +22,11 @@ actor _Connection is mare.WebSocketServerActor
   let _components: _ComponentRegistry ref
   let _render_sink: _RenderSink ref = _RenderSink
 
-  new create(auth: lori.TCPServerAuth, fd: U32,
-    config: mare.WebSocketConfig val, routes: Routes val,
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: mare.WebSocketConfig val,
+    routes: Routes val,
     pub_sub: PubSub tag)
   =>
     _assigns = Assigns
@@ -38,7 +41,8 @@ actor _Connection is mare.WebSocketServerActor
     _ws
 
   fun ref on_open(request: mare.UpgradeRequest val) =>
-    let factory = match _router(request.uri)
+    let factory =
+      match \exhaustive\ _router(request.uri)
       | let f: Factory => f
       | None =>
         _ws.send_text(_WireProtocol.encode_error("no_route"))
@@ -46,7 +50,8 @@ actor _Connection is mare.WebSocketServerActor
         return
       end
 
-    let view = try factory()?
+    let view =
+      try factory()?
       else
         _ws.send_text(_WireProtocol.encode_error("factory_failed"))
         _ws.close()
@@ -83,12 +88,12 @@ actor _Connection is mare.WebSocketServerActor
   fun ref on_text_message(data: String val) =>
     match _view
     | let v: LiveView ref =>
-      match _WireProtocol.decode_client_message(data)
+      match \exhaustive\ _WireProtocol.decode_client_message(data)
       | let msg: _EventMessage =>
-        match msg.target
+        match \exhaustive\ msg.target
         | let component_id: String =>
-          if not _components.handle_event(component_id, msg.event,
-            msg.payload)
+          if not _components.handle_event(
+            component_id, msg.event, msg.payload)
           then
             _ws.send_text(
               _WireProtocol.encode_error("unknown_component"))
@@ -146,7 +151,7 @@ actor _Connection is mare.WebSocketServerActor
     """
     _render_sink.begin()
     if v.render_parts(_assigns, _render_sink) then
-      match _render_sink.result()
+      match \exhaustive\ _render_sink.result()
       | let full: _FullRender =>
         _last_html = _render_sink.full_html()
         _ws.send_text(

--- a/livery/_render_sink.pony
+++ b/livery/_render_sink.pony
@@ -41,7 +41,6 @@ class _RenderSink is templates.TemplateSink
   // Cached state from previous render
   var _cached_statics: (Array[String] val | None) = None
   var _prev_dynamics: (Array[String] val | None) = None
-
   // Transient state for the current render
   var _temp_statics: Array[String] iso = recover iso Array[String] end
   var _temp_dynamics: Array[String] iso = recover iso Array[String] end
@@ -120,12 +119,13 @@ class _RenderSink is templates.TemplateSink
       _temp_changes = recover iso Array[(USize, String)] end
 
     // Check for statics mismatch (count or content)
-    let statics_changed = _statics_mismatch
-      or match _cached_statics
-        | let cached: Array[String] val =>
-          cached.size() != new_statics.size()
-        | None => true
-        end
+    let statics_changed =
+      _statics_mismatch or
+      match \exhaustive\ _cached_statics
+      | let cached: Array[String] val =>
+        cached.size() != new_statics.size()
+      | None => true
+      end
 
     // Update cached state
     _cached_statics = new_statics

--- a/livery/_test.pony
+++ b/livery/_test.pony
@@ -20,7 +20,7 @@ actor \nodoc\ Main is TestList
     // Wire protocol decode tests
     test(_TestDecodeEvent)
     test(_TestDecodeHeartbeat)
-    test(_TestDecodeInvalidJson)
+    test(_TestDecodeInvalidJSON)
     test(_TestDecodeMissingType)
     test(_TestDecodeUnknownType)
     // Router tests
@@ -65,16 +65,16 @@ actor \nodoc\ Main is TestList
     test(_TestRegistryRenderChanged)
     test(_TestRegistryRenderUnchangedCached)
     test(_TestRegistryRenderFailure)
-    test(_TestRegistryPopulateComponentHtml)
+    test(_TestRegistryPopulateComponentHTML)
     // Wire protocol component target tests
     test(_TestDecodeEventWithTarget)
     test(_TestDecodeEventWithoutTarget)
     test(_TestDecodeEventNonStringTarget)
     // Assigns component HTML tests
-    test(_TestAssignsComponentHtml)
-    test(_TestAssignsComponentHtmlUnknown)
-    test(_TestAssignsClearComponentHtml)
-    test(_TestAssignsComponentHtmlSeparateNamespace)
+    test(_TestAssignsComponentHTML)
+    test(_TestAssignsComponentHTMLUnknown)
+    test(_TestAssignsClearComponentHTML)
+    test(_TestAssignsComponentHTMLSeparateNamespace)
     test(_TestAssignsRenderValues)
     // Security tests
     test(_TestRegistryEmptyStringTarget)
@@ -99,7 +99,7 @@ actor \nodoc\ Main is TestList
     test(_TestRenderSinkAbandon)
     test(Property1UnitTest[(USize, Bool)](_TestRenderSinkDiffProperty))
     test(_TestRenderSinkFallbackPattern)
-    test(_TestRenderSinkFullHtmlBeforeRender)
+    test(_TestRenderSinkFullHTMLBeforeRender)
     // Wire protocol split render tests
     test(_TestEncodeRenderFull)
     test(_TestEncodeRenderDiff)
@@ -108,12 +108,13 @@ actor \nodoc\ Main is TestList
     test(_TestLiveViewRenderPartsDefault)
 
 // --- Test helpers ---
-
 class \nodoc\ _DummyView is LiveView
   new create() => None
   fun ref mount(socket: Socket ref) => None
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: Socket ref)
   =>
     None
@@ -172,7 +173,6 @@ actor \nodoc\ _DummyInfoReceiver is InfoReceiver
   be info(message: Any val) => None
 
 // --- Assigns property tests ---
-
 class \nodoc\ _AssignsDirtyTracking is Property1[String]
   fun name(): String => "assigns/dirty_tracking"
 
@@ -187,11 +187,12 @@ class \nodoc\ _AssignsDirtyTracking is Property1[String]
     h.assert_true(assigns.changed(), "update should make assigns dirty")
 
     assigns.clear_changes()
-    h.assert_false(assigns.changed(),
-      "clear_changes should reset dirty flag")
+    h.assert_false(
+      assigns.changed(), "clear_changes should reset dirty flag")
 
     assigns.update(key, "another")
-    h.assert_true(assigns.changed(),
+    h.assert_true(
+      assigns.changed(),
       "update after clear should make assigns dirty again")
 
 class \nodoc\ _AssignsValueRoundtrip is Property1[String]
@@ -220,13 +221,13 @@ class \nodoc\ _AssignsTemplateBridge is Property1[String]
     h.assert_eq[String](value, retrieved)
 
 // --- Wire protocol encode tests ---
-
 class \nodoc\ _TestEncodeRender is UnitTest
   fun name(): String => "wire_protocol/encode_render"
 
   fun apply(h: TestHelper) ? =>
     let encoded = _WireProtocol.encode_render("<h1>hello</h1>")
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -244,7 +245,8 @@ class \nodoc\ _TestEncodeHeartbeatAck is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let encoded = _WireProtocol.encode_heartbeat_ack()
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -259,7 +261,8 @@ class \nodoc\ _TestEncodePushEvent is UnitTest
   fun apply(h: TestHelper) ? =>
     let payload = json.JsonObject.update("key", "value")
     let encoded = _WireProtocol.encode_push_event("notify", payload)
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -277,7 +280,8 @@ class \nodoc\ _TestEncodeError is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let encoded = _WireProtocol.encode_error("render_failed")
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -291,7 +295,6 @@ class \nodoc\ _TestEncodeError is UnitTest
     end
 
 // --- Wire protocol decode tests ---
-
 class \nodoc\ _TestDecodeEvent is UnitTest
   fun name(): String => "wire_protocol/decode_event"
 
@@ -336,7 +339,7 @@ class \nodoc\ _TestDecodeHeartbeat is UnitTest
       h.fail("expected _HeartbeatMessage")
     end
 
-class \nodoc\ _TestDecodeInvalidJson is UnitTest
+class \nodoc\ _TestDecodeInvalidJSON is UnitTest
   fun name(): String => "wire_protocol/decode_invalid_json"
 
   fun apply(h: TestHelper) =>
@@ -378,15 +381,14 @@ class \nodoc\ _TestDecodeUnknownType is UnitTest
     end
 
 // --- Router tests ---
-
 class \nodoc\ _TestRouterExactMatch is UnitTest
   fun name(): String => "router/exact_match"
 
   fun apply(h: TestHelper) ? =>
     let router = Router
-    router.route("/test", {(): LiveView ref^ => _DummyView} val)
+    router.route("/test", {(): LiveView ref^ => _DummyView } val)
     let routes = router.build()
-    match routes("/test")
+    match \exhaustive\ routes("/test")
     | let f: Factory => f()?
     | None => h.fail("expected factory, got None"); error
     end
@@ -396,9 +398,9 @@ class \nodoc\ _TestRouterNoMatch is UnitTest
 
   fun apply(h: TestHelper) =>
     let router = Router
-    router.route("/test", {(): LiveView ref^ => _DummyView} val)
+    router.route("/test", {(): LiveView ref^ => _DummyView } val)
     let routes = router.build()
-    match routes("/other")
+    match \exhaustive\ routes("/other")
     | let _: Factory => h.fail("expected None, got factory")
     | None => None
     end
@@ -409,7 +411,7 @@ class \nodoc\ _TestRouterEmpty is UnitTest
   fun apply(h: TestHelper) =>
     let router = Router
     let routes = router.build()
-    match routes("/anything")
+    match \exhaustive\ routes("/anything")
     | let _: Factory => h.fail("expected None from empty router")
     | None => None
     end
@@ -419,15 +421,14 @@ class \nodoc\ _TestRouterQueryStrip is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let router = Router
-    router.route("/path", {(): LiveView ref^ => _DummyView} val)
+    router.route("/path", {(): LiveView ref^ => _DummyView } val)
     let routes = router.build()
-    match routes("/path?foo=bar&baz=1")
+    match \exhaustive\ routes("/path?foo=bar&baz=1")
     | let f: Factory => f()?
     | None => h.fail("expected factory after query strip"); error
     end
 
 // --- Socket tests ---
-
 class \nodoc\ _TestSocketPushEvent is UnitTest
   fun name(): String => "socket/push_event"
 
@@ -435,8 +436,9 @@ class \nodoc\ _TestSocketPushEvent is UnitTest
     let assigns = Assigns
     let pending = Array[(String val, json.JsonValue)]
     let components = _ComponentRegistry(pending)
-    let socket = Socket(assigns, pending, _DummyInfoReceiver, PubSub,
-      components)
+    let socket =
+      Socket(
+        assigns, pending, _DummyInfoReceiver, PubSub, components)
     socket.push_event("test_event", "payload_value")
 
     h.assert_eq[USize](1, pending.size())
@@ -444,29 +446,28 @@ class \nodoc\ _TestSocketPushEvent is UnitTest
     h.assert_eq[String val]("test_event", event)
 
 // --- PubSub tests ---
-
 class \nodoc\ _TestPubSubDeliver is UnitTest
   fun name(): String => "pub_sub/deliver"
 
   fun apply(h: TestHelper) =>
     h.long_test(2_000_000_000)
     let receiver = _TestInfoReceiver(h)
-    let pub_sub = PubSub
-    pub_sub.subscribe("topic", receiver)
-    pub_sub.publish("topic", "hello")
+    PubSub
+      .> subscribe("topic", receiver)
+      .> publish("topic", "hello")
 
 class \nodoc\ _TestPubSubNoSubscribers is UnitTest
   fun name(): String => "pub_sub/no_subscribers"
 
   fun apply(h: TestHelper) =>
     h.long_test(2_000_000_000)
-    let pub_sub = PubSub
-    // Publishing to an empty topic should not crash
-    pub_sub.publish("empty_topic", "hello")
-    // Use a sentinel to prove the publish was processed
+    // Publishing to an empty topic should not crash.
+    // Use a sentinel to prove the publish was processed.
     let receiver = _TestInfoReceiver(h)
-    pub_sub.subscribe("proof", receiver)
-    pub_sub.publish("proof", "done")
+    PubSub
+      .> publish("empty_topic", "hello")
+      .> subscribe("proof", receiver)
+      .> publish("proof", "done")
 
 class \nodoc\ _TestPubSubUnsubscribe is UnitTest
   fun name(): String => "pub_sub/unsubscribe"
@@ -475,11 +476,11 @@ class \nodoc\ _TestPubSubUnsubscribe is UnitTest
     h.long_test(2_000_000_000)
     let guarded = _GuardedInfoReceiver
     let sentinel = _SentinelInfoReceiver(h, guarded)
-    let pub_sub = PubSub
-    pub_sub.subscribe("topic", guarded)
-    pub_sub.subscribe("topic", sentinel)
-    pub_sub.unsubscribe("topic", guarded)
-    pub_sub.publish("topic", "after_unsub")
+    PubSub
+      .> subscribe("topic", guarded)
+      .> subscribe("topic", sentinel)
+      .> unsubscribe("topic", guarded)
+      .> publish("topic", "after_unsub")
 
 class \nodoc\ _TestPubSubUnsubscribeAll is UnitTest
   fun name(): String => "pub_sub/unsubscribe_all"
@@ -488,12 +489,12 @@ class \nodoc\ _TestPubSubUnsubscribeAll is UnitTest
     h.long_test(2_000_000_000)
     let guarded = _GuardedInfoReceiver
     let sentinel = _SentinelInfoReceiver(h, guarded)
-    let pub_sub = PubSub
-    pub_sub.subscribe("topic_a", guarded)
-    pub_sub.subscribe("topic_b", guarded)
-    pub_sub.subscribe("topic_a", sentinel)
-    pub_sub.unsubscribe_all(guarded)
-    pub_sub.publish("topic_a", "after_unsub_all")
+    PubSub
+      .> subscribe("topic_a", guarded)
+      .> subscribe("topic_b", guarded)
+      .> subscribe("topic_a", sentinel)
+      .> unsubscribe_all(guarded)
+      .> publish("topic_a", "after_unsub_all")
 
 class \nodoc\ _TestPubSubMultipleSubscribers is UnitTest
   fun name(): String => "pub_sub/multiple_subscribers"
@@ -543,7 +544,6 @@ actor \nodoc\ _ForwardingInfoReceiver is InfoReceiver
     _counter.received()
 
 // --- Socket connected tests ---
-
 class \nodoc\ _TestSocketConnectedTrue is UnitTest
   fun name(): String => "socket/connected_true"
 
@@ -551,9 +551,11 @@ class \nodoc\ _TestSocketConnectedTrue is UnitTest
     let assigns = Assigns
     let pending = Array[(String val, json.JsonValue)]
     let components = _ComponentRegistry(pending)
-    let socket = Socket(assigns, pending, _DummyInfoReceiver, PubSub,
-      components)
-    h.assert_true(socket.connected(),
+    let socket =
+      Socket(
+        assigns, pending, _DummyInfoReceiver, PubSub, components)
+    h.assert_true(
+      socket.connected(),
       "socket created via create should be connected")
 
 class \nodoc\ _TestSocketConnectedFalse is UnitTest
@@ -563,7 +565,8 @@ class \nodoc\ _TestSocketConnectedFalse is UnitTest
     let assigns = Assigns
     let pending = Array[(String val, json.JsonValue)]
     let socket = Socket._for_render(assigns, pending)
-    h.assert_false(socket.connected(),
+    h.assert_false(
+      socket.connected(),
       "socket created via _for_render should not be connected")
 
 class \nodoc\ _TestSocketDisconnectedSubscribeNoop is UnitTest
@@ -572,19 +575,21 @@ class \nodoc\ _TestSocketDisconnectedSubscribeNoop is UnitTest
   fun apply(h: TestHelper) =>
     let assigns = Assigns
     let pending = Array[(String val, json.JsonValue)]
-    let socket = Socket._for_render(assigns, pending)
     // These should not crash — they no-op when PubSub is None
-    socket.subscribe("topic")
-    socket.unsubscribe("topic")
+    Socket._for_render(assigns, pending)
+      .> subscribe("topic")
+      .> unsubscribe("topic")
 
 // --- PageRenderer tests ---
-
 class \nodoc\ _RenderTestView is LiveView
   new create() => None
+
   fun ref mount(socket: Socket ref) =>
     socket.assign("greeting", "hello")
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: Socket ref)
   =>
     None
@@ -600,7 +605,9 @@ class \nodoc\ _FailRenderView is LiveView
   new create() => None
   fun ref mount(socket: Socket ref) => None
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: Socket ref)
   =>
     None
@@ -613,8 +620,8 @@ class \nodoc\ _TestPageRendererSuccess is UnitTest
 
   fun apply(h: TestHelper) =>
     let factory: Factory =
-      {(): LiveView ref^ => _RenderTestView} val
-    match PageRenderer.render(factory)
+      {(): LiveView ref^ => _RenderTestView } val
+    match \exhaustive\ PageRenderer.render(factory)
     | let html: String val =>
       h.assert_eq[String]("hello", html)
     | let err: PageRenderError =>
@@ -626,8 +633,8 @@ class \nodoc\ _TestPageRendererFactoryFailed is UnitTest
 
   fun apply(h: TestHelper) =>
     let factory: Factory =
-      {(): LiveView ref^ ? => error} val
-    match PageRenderer.render(factory)
+      {(): LiveView ref^ ? => error } val
+    match \exhaustive\ PageRenderer.render(factory)
     | let _: String val =>
       h.fail("expected PageRenderFactoryFailed, got HTML")
     | let _: PageRenderFactoryFailed => None
@@ -640,8 +647,8 @@ class \nodoc\ _TestPageRendererRenderFailed is UnitTest
 
   fun apply(h: TestHelper) =>
     let factory: Factory =
-      {(): LiveView ref^ => _FailRenderView} val
-    match PageRenderer.render(factory)
+      {(): LiveView ref^ => _FailRenderView } val
+    match \exhaustive\ PageRenderer.render(factory)
     | let _: String val =>
       h.fail("expected PageRenderFailed, got HTML")
     | let _: PageRenderFactoryFailed =>
@@ -659,7 +666,9 @@ class \nodoc\ _ConnectedBranchView is LiveView
       socket.assign("mode", "static")
     end
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: Socket ref)
   =>
     None
@@ -676,8 +685,8 @@ class \nodoc\ _TestPageRendererDisconnectedSocket is UnitTest
 
   fun apply(h: TestHelper) =>
     let factory: Factory =
-      {(): LiveView ref^ => _ConnectedBranchView} val
-    match PageRenderer.render(factory)
+      {(): LiveView ref^ => _ConnectedBranchView } val
+    match \exhaustive\ PageRenderer.render(factory)
     | let html: String val =>
       h.assert_eq[String]("static", html)
     | let err: PageRenderError =>
@@ -693,15 +702,17 @@ class \nodoc\ _ComponentView is LiveView
   fun ref mount(socket: Socket ref) =>
     let comp = _TestComponent
     if socket.register_component("c1", comp) then
-      socket.update_component("c1",
+      socket.update_component(
+        "c1",
         recover val
-          let d = Array[(String, (String | templates.TemplateValue))]
-          d.push(("greeting", "from_component"))
-          d
+          Array[(String, (String | templates.TemplateValue))]
+            .> push(("greeting", "from_component"))
         end)
     end
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: Socket ref)
   =>
     None
@@ -714,8 +725,8 @@ class \nodoc\ _TestPageRendererWithComponents is UnitTest
 
   fun apply(h: TestHelper) =>
     let factory: Factory =
-      {(): LiveView ref^ => _ComponentView} val
-    match PageRenderer.render(factory)
+      {(): LiveView ref^ => _ComponentView } val
+    match \exhaustive\ PageRenderer.render(factory)
     | let html: String val =>
       h.assert_eq[String]("from_component", html)
     | let err: PageRenderError =>
@@ -723,7 +734,6 @@ class \nodoc\ _TestPageRendererWithComponents is UnitTest
     end
 
 // --- Socket + PubSub integration tests ---
-
 class \nodoc\ _TestSocketSubscribeDeliver is UnitTest
   fun name(): String => "socket/subscribe_deliver"
 
@@ -739,7 +749,6 @@ class \nodoc\ _TestSocketSubscribeDeliver is UnitTest
     pub_sub.publish("test_topic", "hello")
 
 // --- Component test helpers ---
-
 class \nodoc\ _TestComponent is LiveComponent
   """
   Minimal test component that renders a greeting from its assigns.
@@ -751,7 +760,9 @@ class \nodoc\ _TestComponent is LiveComponent
   fun ref mount(socket: ComponentSocket ref) =>
     mount_called = true
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: ComponentSocket ref)
   =>
     match event
@@ -778,7 +789,9 @@ class \nodoc\ _FailingComponent is LiveComponent
 
   fun ref mount(socket: ComponentSocket ref) => None
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: ComponentSocket ref)
   =>
     None
@@ -787,7 +800,6 @@ class \nodoc\ _FailingComponent is LiveComponent
     error
 
 // --- ComponentSocket tests ---
-
 class \nodoc\ _TestComponentSocketAssignRoundtrip is UnitTest
   fun name(): String => "component_socket/assign_roundtrip"
 
@@ -813,7 +825,6 @@ class \nodoc\ _TestComponentSocketPushEvent is UnitTest
     h.assert_eq[String val]("notify", event)
 
 // --- Component registry tests ---
-
 class \nodoc\ _TestRegistryRegisterAndLookup is UnitTest
   fun name(): String => "registry/register_and_lookup"
 
@@ -825,7 +836,8 @@ class \nodoc\ _TestRegistryRegisterAndLookup is UnitTest
     h.assert_true(registry.register("c1", component))
     h.assert_true(registry.has("c1"))
     h.assert_eq[USize](1, registry.size())
-    h.assert_true(component.mount_called,
+    h.assert_true(
+      component.mount_called,
       "mount should be called during registration")
 
 class \nodoc\ _TestRegistryMaxComponents is UnitTest
@@ -836,7 +848,8 @@ class \nodoc\ _TestRegistryMaxComponents is UnitTest
     let registry = _ComponentRegistry(pending where max_components = 2)
     h.assert_true(registry.register("c1", _TestComponent))
     h.assert_true(registry.register("c2", _TestComponent))
-    h.assert_false(registry.register("c3", _TestComponent),
+    h.assert_false(
+      registry.register("c3", _TestComponent),
       "should reject registration at capacity")
     h.assert_eq[USize](2, registry.size())
 
@@ -875,7 +888,8 @@ class \nodoc\ _TestRegistryDuplicateIdAtCapacity is UnitTest
     let registry = _ComponentRegistry(pending where max_components = 1)
     registry.register("c1", _TestComponent)
     // Re-registering existing ID at capacity should succeed (replacement)
-    h.assert_true(registry.register("c1", _TestComponent),
+    h.assert_true(
+      registry.register("c1", _TestComponent),
       "replacing existing ID at capacity should succeed")
     h.assert_eq[USize](1, registry.size())
 
@@ -887,11 +901,11 @@ class \nodoc\ _TestRegistryRegisterAfterUnregister is UnitTest
     let registry = _ComponentRegistry(pending where max_components = 1)
     registry.register("c1", _TestComponent)
     registry.unregister("c1")
-    h.assert_true(registry.register("c2", _TestComponent),
+    h.assert_true(
+      registry.register("c2", _TestComponent),
       "slot should be freed after unregister")
 
 // --- Component event routing tests ---
-
 class \nodoc\ _TestRegistryHandleEventFound is UnitTest
   fun name(): String => "registry/handle_event_found"
 
@@ -911,7 +925,6 @@ class \nodoc\ _TestRegistryHandleEventNotFound is UnitTest
     h.assert_false(registry.handle_event("nonexistent", "click", None))
 
 // --- Component rendering tests ---
-
 class \nodoc\ _TestRegistryRenderChanged is UnitTest
   fun name(): String => "registry/render_changed"
 
@@ -924,9 +937,8 @@ class \nodoc\ _TestRegistryRenderChanged is UnitTest
     // Update assigns to trigger change
     let data: Array[(String, (String | templates.TemplateValue))] val =
       recover val
-        let d = Array[(String, (String | templates.TemplateValue))]
-        d.push(("greeting", "hello"))
-        d
+        Array[(String, (String | templates.TemplateValue))]
+          .> push(("greeting", "hello"))
       end
     registry.update("c1", data)
 
@@ -946,9 +958,8 @@ class \nodoc\ _TestRegistryRenderUnchangedCached is UnitTest
     // Set greeting and render
     let data: Array[(String, (String | templates.TemplateValue))] val =
       recover val
-        let d = Array[(String, (String | templates.TemplateValue))]
-        d.push(("greeting", "cached"))
-        d
+        Array[(String, (String | templates.TemplateValue))]
+          .> push(("greeting", "cached"))
       end
     registry.update("c1", data)
     registry.render_all()
@@ -968,13 +979,15 @@ class \nodoc\ _TestRegistryRenderFailure is UnitTest
     let registry = _ComponentRegistry(pending)
     registry.register("fail", _FailingComponent)
     let errors = registry.flush_render_errors()
-    h.assert_eq[USize](1, errors.size(),
+    h.assert_eq[USize](
+      1,
+      errors.size(),
       "initial render failure should produce an error")
     try
       h.assert_true(errors(0)?.contains("fail"))
     end
 
-class \nodoc\ _TestRegistryPopulateComponentHtml is UnitTest
+class \nodoc\ _TestRegistryPopulateComponentHTML is UnitTest
   fun name(): String => "registry/populate_component_html"
 
   fun apply(h: TestHelper) ? =>
@@ -984,9 +997,8 @@ class \nodoc\ _TestRegistryPopulateComponentHtml is UnitTest
 
     let data: Array[(String, (String | templates.TemplateValue))] val =
       recover val
-        let d = Array[(String, (String | templates.TemplateValue))]
-        d.push(("greeting", "world"))
-        d
+        Array[(String, (String | templates.TemplateValue))]
+          .> push(("greeting", "world"))
       end
     registry.update("c1", data)
     registry.render_all()
@@ -997,7 +1009,6 @@ class \nodoc\ _TestRegistryPopulateComponentHtml is UnitTest
     h.assert_eq[String]("world", html)
 
 // --- Wire protocol component target tests ---
-
 class \nodoc\ _TestDecodeEventWithTarget is UnitTest
   fun name(): String => "wire_protocol/decode_event_with_target"
 
@@ -1012,7 +1023,7 @@ class \nodoc\ _TestDecodeEventWithTarget is UnitTest
     match _WireProtocol.decode_client_message(consume data)
     | let msg: _EventMessage =>
       h.assert_eq[String]("toggle", msg.event)
-      match msg.target
+      match \exhaustive\ msg.target
       | let t: String => h.assert_eq[String]("todo-3", t)
       | None => h.fail("expected target, got None")
       end
@@ -1033,7 +1044,7 @@ class \nodoc\ _TestDecodeEventWithoutTarget is UnitTest
     match _WireProtocol.decode_client_message(consume data)
     | let msg: _EventMessage =>
       h.assert_eq[String]("click", msg.event)
-      match msg.target
+      match \exhaustive\ msg.target
       | let _: String => h.fail("expected None target")
       | None => None
       end
@@ -1054,15 +1065,15 @@ class \nodoc\ _TestDecodeEventNonStringTarget is UnitTest
 
     match _WireProtocol.decode_client_message(consume data)
     | let err: _WireError =>
-      h.assert_true(err.reason.contains("'c'"),
+      h.assert_true(
+        err.reason.contains("'c'"),
         "error should mention 'c' field")
     else
       h.fail("expected _WireError for non-string 'c'")
     end
 
 // --- Assigns component HTML tests ---
-
-class \nodoc\ _TestAssignsComponentHtml is UnitTest
+class \nodoc\ _TestAssignsComponentHTML is UnitTest
   fun name(): String => "assigns/component_html"
 
   fun apply(h: TestHelper) ? =>
@@ -1071,12 +1082,13 @@ class \nodoc\ _TestAssignsComponentHtml is UnitTest
     let html = assigns.component_html("c1")?
     h.assert_eq[String]("<li>item</li>", html)
 
-class \nodoc\ _TestAssignsComponentHtmlUnknown is UnitTest
+class \nodoc\ _TestAssignsComponentHTMLUnknown is UnitTest
   fun name(): String => "assigns/component_html_unknown"
 
   fun apply(h: TestHelper) =>
     let assigns = Assigns
-    let found = try
+    let found =
+      try
         assigns.component_html("nonexistent")?
         true
       else
@@ -1084,14 +1096,15 @@ class \nodoc\ _TestAssignsComponentHtmlUnknown is UnitTest
       end
     h.assert_false(found, "should error for unknown component ID")
 
-class \nodoc\ _TestAssignsClearComponentHtml is UnitTest
+class \nodoc\ _TestAssignsClearComponentHTML is UnitTest
   fun name(): String => "assigns/clear_component_html"
 
   fun apply(h: TestHelper) =>
     let assigns = Assigns
     assigns._set_component_html("c1", "<li>item</li>")
     assigns._clear_component_html()
-    let found = try
+    let found =
+      try
         assigns.component_html("c1")?
         true
       else
@@ -1099,7 +1112,7 @@ class \nodoc\ _TestAssignsClearComponentHtml is UnitTest
       end
     h.assert_false(found, "should be empty after clear")
 
-class \nodoc\ _TestAssignsComponentHtmlSeparateNamespace is UnitTest
+class \nodoc\ _TestAssignsComponentHTMLSeparateNamespace is UnitTest
   fun name(): String => "assigns/component_html_separate_namespace"
 
   fun apply(h: TestHelper) ? =>
@@ -1128,16 +1141,16 @@ class \nodoc\ _TestAssignsRenderValues is UnitTest
     h.assert_eq[String]("world", child_val)
 
 // --- Security tests ---
-
 class \nodoc\ _TestRegistryEmptyStringTarget is UnitTest
   fun name(): String => "registry/empty_string_target"
 
   fun apply(h: TestHelper) =>
     let pending = Array[(String val, json.JsonValue)]
     let registry = _ComponentRegistry(pending)
-    h.assert_false(registry.handle_event("", "click", None),
-      "empty string target should fail when no component registered with " +
-      "that ID")
+    h.assert_false(
+      registry.handle_event("", "click", None),
+      "empty string target should fail when no component " +
+        "registered with that ID")
 
 class \nodoc\ _TestRegistryLongTarget is UnitTest
   fun name(): String => "registry/long_target"
@@ -1145,10 +1158,12 @@ class \nodoc\ _TestRegistryLongTarget is UnitTest
   fun apply(h: TestHelper) =>
     let pending = Array[(String val, json.JsonValue)]
     let registry = _ComponentRegistry(pending)
-    let long_id = recover val
-      String(10000).>append("a" * 10000)
-    end
-    h.assert_false(registry.handle_event(long_id, "click", None),
+    let long_id =
+      recover val
+        String(10000) .> append("a" * 10000)
+      end
+    h.assert_false(
+      registry.handle_event(long_id, "click", None),
       "very long target should fail without crashing")
 
 class \nodoc\ _TestComponentIsolation is UnitTest
@@ -1162,17 +1177,15 @@ class \nodoc\ _TestComponentIsolation is UnitTest
 
     let data_a: Array[(String, (String | templates.TemplateValue))] val =
       recover val
-        let d = Array[(String, (String | templates.TemplateValue))]
-        d.push(("greeting", "alpha"))
-        d
+        Array[(String, (String | templates.TemplateValue))]
+          .> push(("greeting", "alpha"))
       end
     registry.update("a", data_a)
 
     let data_b: Array[(String, (String | templates.TemplateValue))] val =
       recover val
-        let d = Array[(String, (String | templates.TemplateValue))]
-        d.push(("greeting", "beta"))
-        d
+        Array[(String, (String | templates.TemplateValue))]
+          .> push(("greeting", "beta"))
       end
     registry.update("b", data_b)
 
@@ -1181,7 +1194,6 @@ class \nodoc\ _TestComponentIsolation is UnitTest
     h.assert_eq[String]("beta", registry.component_html("b")?)
 
 // --- RenderSink roundtrip tests ---
-
 class \nodoc\ _TestRenderSinkRoundtrip is Property1[String]
   """
   render_to(sink) -> full_html() matches HtmlTemplate.render() for a
@@ -1221,8 +1233,9 @@ class \nodoc\ _TestRenderSinkRoundtripMultiVar is
 
   fun property(sample: (String, String, String), h: PropertyHelper) ? =>
     (let a, let b, let c) = sample
-    let tmpl = templates.HtmlTemplate.parse(
-      "<p>{{ x }}</p><p>{{ y }}</p><p>{{ z }}</p>")?
+    let tmpl =
+      templates.HtmlTemplate.parse(
+        "<p>{{ x }}</p><p>{{ y }}</p><p>{{ z }}</p>")?
     let tv = templates.TemplateValues
     tv("x") = a
     tv("y") = b
@@ -1244,8 +1257,9 @@ class \nodoc\ _TestRenderSinkIfCollapse is UnitTest
   fun name(): String => "render_sink/if_collapse"
 
   fun apply(h: TestHelper) ? =>
-    let tmpl = templates.HtmlTemplate.parse(
-      "<div>{{ if show }}visible{{ end }}</div>")?
+    let tmpl =
+      templates.HtmlTemplate.parse(
+        "<div>{{ if show }}visible{{ end }}</div>")?
     let tv = templates.TemplateValues
     tv("show") = "true"
 
@@ -1302,40 +1316,43 @@ class \nodoc\ _TestRenderSinkInterleave is Property1[USize]
 
   fun property(n: USize, h: PropertyHelper) ? =>
     // Build deterministic statics and dynamics based on n
-    let statics = recover val
-      let arr = Array[String](n + 1)
-      var i: USize = 0
-      while i < (n + 1) do
-        arr.push("s" + i.string())
-        i = i + 1
+    let statics =
+      recover val
+        let arr = Array[String](n + 1)
+        var i: USize = 0
+        while i < (n + 1) do
+          arr.push("s" + i.string())
+          i = i + 1
+        end
+        arr
       end
-      arr
-    end
-    let dynamics = recover val
-      let arr = Array[String](n)
-      var i: USize = 0
-      while i < n do
-        arr.push("d" + i.string())
-        i = i + 1
+    let dynamics =
+      recover val
+        let arr = Array[String](n)
+        var i: USize = 0
+        while i < n do
+          arr.push("d" + i.string())
+          i = i + 1
+        end
+        arr
       end
-      arr
-    end
 
     // Build expected string manually
-    let expected = recover val
-      var total: USize = 0
-      for s in statics.values() do total = total + s.size() end
-      for d in dynamics.values() do total = total + d.size() end
-      let out = String(total)
-      var i: USize = 0
-      while i < dynamics.size() do
+    let expected =
+      recover val
+        var total: USize = 0
+        for s in statics.values() do total = total + s.size() end
+        for d in dynamics.values() do total = total + d.size() end
+        let out = String(total)
+        var i: USize = 0
+        while i < dynamics.size() do
+          out.append(statics(i)?)
+          out.append(dynamics(i)?)
+          i = i + 1
+        end
         out.append(statics(i)?)
-        out.append(dynamics(i)?)
-        i = i + 1
+        out
       end
-      out.append(statics(i)?)
-      out
-    end
 
     // Drive the sink manually
     let sink: _RenderSink ref = _RenderSink
@@ -1363,8 +1380,9 @@ class \nodoc\ _TestRenderSinkDynamicsCountChange is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let tmpl1 = templates.HtmlTemplate.parse("<div>{{ x }}</div>")?
-    let tmpl2 = templates.HtmlTemplate.parse(
-      "<p>{{ a }}</p><p>{{ b }}</p>")?
+    let tmpl2 =
+      templates.HtmlTemplate.parse(
+        "<p>{{ a }}</p><p>{{ b }}</p>")?
     let tv = templates.TemplateValues
     tv("x") = "one"
     tv("a") = "two"
@@ -1407,7 +1425,6 @@ class \nodoc\ _TestRenderSinkEscapingRoundtrip is UnitTest
     h.assert_eq[String](expected, sink.full_html())
 
 // --- RenderSink diff tests ---
-
 class \nodoc\ _TestRenderSinkFirstRender is UnitTest
   """
   First result() returns _FullRender.
@@ -1466,8 +1483,9 @@ class \nodoc\ _TestRenderSinkPartialDiff is UnitTest
   fun name(): String => "render_sink/partial_diff"
 
   fun apply(h: TestHelper) ? =>
-    let tmpl = templates.HtmlTemplate.parse(
-      "<p>{{ a }}</p><p>{{ b }}</p><p>{{ c }}</p>")?
+    let tmpl =
+      templates.HtmlTemplate.parse(
+        "<p>{{ a }}</p><p>{{ b }}</p><p>{{ c }}</p>")?
     let tv = templates.TemplateValues
     tv("a") = "1"
     tv("b") = "2"
@@ -1499,8 +1517,9 @@ class \nodoc\ _TestRenderSinkAllSlotsDiff is UnitTest
   fun name(): String => "render_sink/all_slots_diff"
 
   fun apply(h: TestHelper) ? =>
-    let tmpl = templates.HtmlTemplate.parse(
-      "<p>{{ a }}</p><p>{{ b }}</p>")?
+    let tmpl =
+      templates.HtmlTemplate.parse(
+        "<p>{{ a }}</p><p>{{ b }}</p>")?
     let tv = templates.TemplateValues
     tv("a") = "1"
     tv("b") = "2"
@@ -1629,15 +1648,16 @@ class \nodoc\ _TestRenderSinkDiffProperty is Property1[(USize, Bool)]
   fun property(sample: (USize, Bool), h: PropertyHelper) =>
     (let n, let do_changes) = sample
     // Build a template with N slots
-    let tmpl_str = recover val
-      let s = String
-      var i: USize = 0
-      while i < n do
-        s.append("{{ v" + i.string() + " }}")
-        i = i + 1
+    let tmpl_str =
+      recover val
+        let s = String
+        var i: USize = 0
+        while i < n do
+          s.append("{{ v" + i.string() + " }}")
+          i = i + 1
+        end
+        s
       end
-      s
-    end
 
     try
       let tmpl = templates.HtmlTemplate.parse(tmpl_str)?
@@ -1672,7 +1692,7 @@ class \nodoc\ _TestRenderSinkDiffProperty is Property1[(USize, Bool)]
       tmpl.render_to(sink, tv)?
       let diff = sink.result()
 
-      match diff
+      match \exhaustive\ diff
       | let slot_diff: _SlotDiff =>
         h.assert_eq[USize](expected_changes.size(), slot_diff.changes.size())
         var j: USize = 0
@@ -1688,7 +1708,9 @@ class \nodoc\ _TestRenderSinkDiffProperty is Property1[(USize, Bool)]
           j = j + 1
         end
       | _NoChange =>
-        h.assert_eq[USize](0, expected_changes.size(),
+        h.assert_eq[USize](
+          0,
+          expected_changes.size(),
           "got _NoChange but expected changes")
       | let _: _FullRender =>
         // The generator never changes statics between renders, so this arm
@@ -1744,7 +1766,7 @@ class \nodoc\ _TestRenderSinkFallbackPattern is UnitTest
       h.fail("expected _FullRender after empty abandon + fresh render")
     end
 
-class \nodoc\ _TestRenderSinkFullHtmlBeforeRender is UnitTest
+class \nodoc\ _TestRenderSinkFullHTMLBeforeRender is UnitTest
   """
   full_html() on a fresh sink (no render transaction) returns empty string.
   """
@@ -1755,7 +1777,6 @@ class \nodoc\ _TestRenderSinkFullHtmlBeforeRender is UnitTest
     h.assert_eq[String]("", sink.full_html())
 
 // --- Wire protocol split render tests ---
-
 class \nodoc\ _TestEncodeRenderFull is UnitTest
   fun name(): String => "wire_protocol/encode_render_full"
 
@@ -1763,7 +1784,8 @@ class \nodoc\ _TestEncodeRenderFull is UnitTest
     let statics: Array[String] val = ["<div>"; "</div>"]
     let dynamics: Array[String] val = ["42"]
     let encoded = _WireProtocol.encode_render_full(statics, dynamics)
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -1800,7 +1822,8 @@ class \nodoc\ _TestEncodeRenderDiff is UnitTest
   fun apply(h: TestHelper) ? =>
     let changes: Array[(USize, String)] val = [(0, "43"); (2, "new")]
     let encoded = _WireProtocol.encode_render_diff(changes)
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -1828,7 +1851,8 @@ class \nodoc\ _TestEncodeRenderDiffEmpty is UnitTest
     let changes: Array[(USize, String)] val =
       recover val Array[(USize, String)] end
     let encoded = _WireProtocol.encode_render_diff(changes)
-    let obj = match json.JsonParser.parse(encoded)
+    let obj =
+      match json.JsonParser.parse(encoded)
       | let o: json.JsonObject => o
       else h.fail("expected JsonObject"); error
       end
@@ -1843,7 +1867,6 @@ class \nodoc\ _TestEncodeRenderDiffEmpty is UnitTest
     end
 
 // --- LiveView default render_parts test ---
-
 class \nodoc\ _TestLiveViewRenderPartsDefault is UnitTest
   fun name(): String => "live_view/render_parts_default"
 
@@ -1851,5 +1874,6 @@ class \nodoc\ _TestLiveViewRenderPartsDefault is UnitTest
     let view: LiveView ref = _DummyView
     let sink: _RenderSink ref = _RenderSink
     let assigns = Assigns
-    h.assert_false(view.render_parts(assigns, sink),
+    h.assert_false(
+      view.render_parts(assigns, sink),
       "default render_parts should return false")

--- a/livery/_unreachable.pony
+++ b/livery/_unreachable.pony
@@ -9,8 +9,9 @@ primitive _Unreachable
   Prints location to stderr and terminates the process.
   """
   fun apply(loc: SourceLoc = __loc) =>
-    @fprintf(@pony_os_stderr(),
-      "Unreachable at %s:%lu. Please open an issue at https://github.com/ponylang/livery/issues\n"
-        .cstring(),
-      loc.file().cstring(), loc.line())
+    @fprintf(
+      @pony_os_stderr(),
+      "Unreachable at %s:%lu. Please open an issue.\n".cstring(),
+      loc.file().cstring(),
+      loc.line())
     @exit(1)

--- a/livery/_wire_protocol.pony
+++ b/livery/_wire_protocol.pony
@@ -85,7 +85,8 @@ primitive _WireProtocol
     """
     Decode a client message from JSON.
     """
-    let obj = match json.JsonParser.parse(data)
+    let obj =
+      match json.JsonParser.parse(data)
       | let o: json.JsonObject => o
       else return _WireError("invalid JSON or not an object")
       end
@@ -141,7 +142,9 @@ class val _EventMessage
   let payload: json.JsonValue
   let target: (String val | None)
 
-  new val create(event': String val, payload': json.JsonValue,
+  new val create(
+    event': String val,
+    payload': json.JsonValue,
     target': (String val | None) = None)
   =>
     event = event'

--- a/livery/assigns.pony
+++ b/livery/assigns.pony
@@ -56,8 +56,9 @@ class Assigns
     """
     Look up the rendered HTML for a registered component.
 
-    Use this in `render()` or `render_parts()` to include component output in the parent's
-    HTML. The returned string is already escaped by the component's own
+    Use this in `render()` or `render_parts()` to include component
+    output in the parent's HTML. The returned string is already escaped
+    by the component's own
     `HtmlTemplate` -- insert it as `TemplateValue.unescaped()` in the
     parent's template values.
     """
@@ -81,8 +82,9 @@ class Assigns
     """
     Create a writable child scope of the backing template values.
 
-    Use this in `render()` or `render_parts()` to overlay component HTML or computed values
-    onto the existing assigns without modifying the underlying state.
+    Use this in `render()` or `render_parts()` to overlay component
+    HTML or computed values onto the existing assigns without modifying
+    the underlying state.
     The child scope falls through to the parent for lookups, so all
     existing assigns remain accessible.
     """

--- a/livery/factory.pony
+++ b/livery/factory.pony
@@ -12,3 +12,6 @@ interface val Factory
   ```
   """
   fun apply(): LiveView ref^ ?
+    """
+    Create a new LiveView instance.
+    """

--- a/livery/info_receiver.pony
+++ b/livery/info_receiver.pony
@@ -7,3 +7,6 @@ interface tag InfoReceiver
   inside a lifecycle method.
   """
   be info(message: Any val)
+    """
+    Deliver a message to the associated LiveView's `handle_info` callback.
+    """

--- a/livery/listener.pony
+++ b/livery/listener.pony
@@ -15,8 +15,13 @@ actor Listener is lori.TCPListenerActor
   let _pub_sub: PubSub tag
   let _out: OutStream tag
 
-  new create(auth: lori.TCPListenAuth, host: String, port: String,
-    routes: Routes val, pub_sub: PubSub tag, out: OutStream tag)
+  new create(
+    auth: lori.TCPListenAuth,
+    host: String,
+    port: String,
+    routes: Routes val,
+    pub_sub: PubSub tag,
+    out: OutStream tag)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = mare.WebSocketConfig(host, port)

--- a/livery/live_component.pony
+++ b/livery/live_component.pony
@@ -34,7 +34,9 @@ trait LiveComponent
     """
     None
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: ComponentSocket ref)
     """
     Called when the client sends an event targeted at this component

--- a/livery/live_view.pony
+++ b/livery/live_view.pony
@@ -25,7 +25,9 @@ trait LiveView
     during HTTP render.
     """
 
-  fun ref handle_event(event: String val, payload: json.JsonValue,
+  fun ref handle_event(
+    event: String val,
+    payload: json.JsonValue,
     socket: Socket ref)
     """
     Called when the client sends a UI event (e.g., a button click or form

--- a/livery/page_renderer.pony
+++ b/livery/page_renderer.pony
@@ -36,7 +36,8 @@ primitive PageRenderer
     Returns the rendered HTML string on success, or a specific error
     indicating whether the factory or the render failed.
     """
-    let view = try factory()?
+    let view =
+      try factory()?
       else return PageRenderFactoryFailed
       end
     let assigns = Assigns

--- a/livery/pub_sub.pony
+++ b/livery/pub_sub.pony
@@ -20,13 +20,14 @@ actor PubSub
     Add a subscriber to a topic. Idempotent — subscribing the same
     connection to the same topic twice has no additional effect.
     """
-    let subs = try
-      _topics(topic)?
-    else
-      let s = collections.SetIs[InfoReceiver tag]
-      _topics(topic) = s
-      s
-    end
+    let subs =
+      try
+        _topics(topic)?
+      else
+        let s = collections.SetIs[InfoReceiver tag]
+        _topics(topic) = s
+        s
+      end
     subs.set(subscriber)
 
   be unsubscribe(topic: String, subscriber: InfoReceiver tag) =>

--- a/livery/socket.pony
+++ b/livery/socket.pony
@@ -16,9 +16,11 @@ class Socket
   let _connected: Bool
   let _components: _ComponentRegistry ref
 
-  new create(assigns: Assigns ref,
+  new create(
+    assigns: Assigns ref,
     pending_events: Array[(String val, json.JsonValue)] ref,
-    self': InfoReceiver tag, pub_sub: PubSub tag,
+    self': InfoReceiver tag,
+    pub_sub: PubSub tag,
     components: _ComponentRegistry ref)
   =>
     _assigns = assigns


### PR DESCRIPTION
Add pony-lint CI workflow and Makefile lint target, and fix all style and safety lint errors across the library, examples, and tests.

No file renames in this PR -- all changes are in-place formatting and annotation fixes.
